### PR TITLE
Remove position: relative from autocomplete list so that it renders o…

### DIFF
--- a/src/lib/auto-complete/index.svelte
+++ b/src/lib/auto-complete/index.svelte
@@ -292,7 +292,6 @@
     right: 0;
     max-height: 210px;
     overflow: auto;
-    position: relative;
     scroll-behavior: smooth;
     overflow-y: scroll;
   }


### PR DESCRIPTION
…n top of other elements instead of pushing them