### PR TITLE
Use flexbox to layout left-hand column of spirit-board.

### DIFF
--- a/static/template/_global/css/board_front/general.css
+++ b/static/template/_global/css/board_front/general.css
@@ -46,6 +46,12 @@ board {
   width: 100%;
   height: 100%;
   border-radius: 15.1px;
+  display: flex;
+  padding-left: 16px;
+  padding-top: 17.75px;
+  padding-bottom: 15px;
+  justify-content: end;
+  flex-direction: column;
 }
 
 board.round-border {
@@ -53,11 +59,9 @@ board.round-border {
 }
 
 spirit-name {
-  position: absolute;
   display: flex;
   align-items: center;
-  left: 45px;
-  top: 734px;
+  margin-left: 29px;
   height: 0px;
   width: 666.25px;
   font-size: 40px;
@@ -101,11 +105,11 @@ custom-meeple {
 }
 
 .spirit-border {
-  position: absolute;
-  left: 0px;
-  top: -50px;
+  margin-left: -15px;
+  margin-right: -8px;
+  margin-top: -50px;
+  margin-bottom: -2px;
   height: 100px;
-  width: 100%;
   z-index: 1;
   background-repeat: no-repeat;
   background-position: left center;
@@ -113,12 +117,11 @@ custom-meeple {
 }
 
 .spirit-image {
-  position: absolute;
-  left: 16.5px;
-  top: 17.75px;
+  margin-left: 0.5px;
+  margin-bottom: -32.75px;
   width: 667.5px;
-  height: calc(100% - (17.75px * 2));
   z-index: -1;
+  flex-grow: 1;
   background-repeat: no-repeat;
 }
 

--- a/static/template/_global/css/board_front/special-rules.css
+++ b/static/template/_global/css/board_front/special-rules.css
@@ -2,11 +2,8 @@ special-rules-container {
   background-image: url("../../images/board/Innate__Special_Rules_Without_Text.png");
   background-repeat: repeat-y;
   background-position: top;
-  position: absolute;
-  left: 16px;
   min-height: 250px;
   padding-bottom: 19px;
-  padding-top: 48px;
   width: 667px;
   display: flex;
   flex-direction: column;

--- a/static/template/_global/js/board_front.js
+++ b/static/template/_global/js/board_front.js
@@ -23,34 +23,8 @@ function startMain() {
 
   setTimeout(function () {
     dynamicCellWidth();
-    dynamicSpecialRuleHeight(board);
     addImages(board);
   }, 200);
-}
-
-function dynamicSpecialRuleHeight(board) {
-  var debug = false;
-  console.log("RESIZING: Special Rule");
-  const specialRules = board.querySelectorAll("special-rules-container")[0];
-  let height = specialRules.getAttribute("height");
-
-  if (!height) {
-    const computedStyle = window.getComputedStyle(specialRules);
-    height = computedStyle.getPropertyValue("height");
-  }
-
-  const spiritName = board.querySelectorAll("spirit-name")[0];
-  if (specialRules) {
-    if (debug) {
-      console.log(`calc(100% - (${height} + 15px))`);
-    }
-    specialRules.style.top = `calc(100% - (${height} + 15px))`;
-
-    specialRules.style.height = height;
-  }
-  if (spiritName) {
-    spiritName.style.top = `calc(100% - (${height} + 15px))`;
-  }
 }
 
 function addImages(board) {
@@ -85,7 +59,7 @@ function addImages(board) {
   if (spiritImage) {
     //Image now scales to fill gap. 'imageSize' allows the user to specify what % of the gap to cover
     board.innerHTML =
-      `<div class="spirit-image" style="background-image: url(${spiritImage}); background-size: auto ${imageSize}; height:calc(100% - ${height}); width:1700px;" ></div>` +
+      `<div class="spirit-image" style="background-image: url(${spiritImage}); background-size: auto ${imageSize}; width:1700px;" ></div>` +
       board.innerHTML;
     artistCredit[0].style.display = "block";
     artistCredit[0].innerHTML = "Artist Credit: " + artistCredit[0].innerHTML;


### PR DESCRIPTION
Instead of trying to use javascript to lay it out dynamically.

In thinking about #145, I wondered if it was possible to use CSS to handle the layout of the left column of spirit boards.
It turns out that it is, and this is the result. I picked the sizes below to exactly mimic the current layout, when testing locally.