### PR TITLE
Stop setting tabindex on elements.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,12 +12,5 @@ module.exports = {
     es6: true,
     node: true,
   },
-  settings: {
-    "svelte3/ignore-warnings": (object) => {
-      if (object.code === "a11y-positive-tabindex") {
-        return true;
-      }
-      return false;
-    },
-  },
+  settings: {},
 };

--- a/src/bulmaOverride.css
+++ b/src/bulmaOverride.css
@@ -55,22 +55,24 @@ h6 {
 }
 
 .button.is-flashy {
-  -webkit-animation: is-flashy 1s step-end infinite;    
-  animation: is-flashy 1s step-end infinite;    
+  -webkit-animation: is-flashy 1s step-end infinite;
+  animation: is-flashy 1s step-end infinite;
 }
-@-webkit-keyframes is-flashy {    
-  from, to {    
-      border-color: transparent    
-  }    
-  50% {    
-      border-color: black    
-  }    
-}    
-@keyframes is-flashy {    
-  from, to {    
-      border-color: transparent    
-  }    
-  50% {    
-      border-color: black    
-  }    
-}   
+@-webkit-keyframes is-flashy {
+  from,
+  to {
+    border-color: transparent;
+  }
+  50% {
+    border-color: black;
+  }
+}
+@keyframes is-flashy {
+  from,
+  to {
+    border-color: transparent;
+  }
+  50% {
+    border-color: black;
+  }
+}

--- a/src/lib/auto-complete/index.svelte
+++ b/src/lib/auto-complete/index.svelte
@@ -8,7 +8,6 @@
   export let startCharacter = "{";
   export let value;
   export let id;
-  export let tabindex = "1";
   export let classNames = "";
   export let showListImmediately;
 
@@ -237,7 +236,6 @@
       class={`input ${classNames}`}
       type="text"
       {placeholder}
-      {tabindex}
       autocomplete="off"
       on:input={handleInputAndFocus}
       on:focus={handleInputAndFocus}
@@ -254,7 +252,6 @@
       on:focus={handleInputAndFocus}
       on:blur={closeAutoComplete}
       on:keydown={handleAutoCompleteKeyboardInput}
-      {tabindex}
       bind:value />
   {/if}
   {#if showAutoCompleteList === true}

--- a/src/lib/preview-frame.svelte
+++ b/src/lib/preview-frame.svelte
@@ -46,5 +46,10 @@
 </script>
 
 <div {id} class="preview-wrap" class:large bind:this={wrapper}>
-  <iframe {src} bind:this={previewIframe} class="preview-frame" id="preview-iframe" title="Preview" />
+  <iframe
+    {src}
+    bind:this={previewIframe}
+    class="preview-frame"
+    id="preview-iframe"
+    title="Preview" />
 </div>

--- a/src/routes/adversary/adversary-levels.svelte
+++ b/src/routes/adversary/adversary-levels.svelte
@@ -42,7 +42,6 @@
             class="input"
             type="text"
             placeholder="Name"
-            tabindex="1"
             bind:value={level.name} />
         </div>
         <div class="control" style="width:15%; min-width:2rem;">
@@ -51,7 +50,6 @@
             class="input"
             type="text"
             placeholder="Difficulty"
-            tabindex="1"
             bind:value={level.difficulty} />
         </div>
         <div class="control" style="width:15%; min-width:2rem;">
@@ -60,7 +58,6 @@
             class="input"
             type="text"
             placeholder="Fear Cards"
-            tabindex="1"
             bind:value={level.fearCards} />
         </div>
       </div>
@@ -70,7 +67,6 @@
           elementType="textarea"
           classNames="is-small"
           placeholder="Effect"
-          tabindex="1"
           validAutoCompleteValues={iconValuesSorted}
           bind:value={level.effect} />
       </div>

--- a/src/routes/adversary/name-loss-escalation.svelte
+++ b/src/routes/adversary/name-loss-escalation.svelte
@@ -54,7 +54,6 @@
           class="input"
           type="text"
           placeholder="Name"
-          tabindex="1"
           bind:value={adversary.nameLossEscalation.name} />
       </div>
       <div class="control" style="width:20%; min-width:2rem;">
@@ -63,7 +62,6 @@
           class="input"
           type="text"
           placeholder="Difficulty"
-          tabindex="1"
           bind:value={adversary.nameLossEscalation.baseDif} />
       </div>
     </div>
@@ -101,7 +99,6 @@
           class="input"
           type="text"
           placeholder="Name"
-          tabindex="1"
           bind:value={adversary.nameLossEscalation.lossCondition.name} />
       </div>
     </div>
@@ -111,7 +108,6 @@
         elementType="textarea"
         placeholder="Effect"
         classNames="is-small"
-        tabindex="1"
         validAutoCompleteValues={iconValuesSorted}
         bind:value={adversary.nameLossEscalation.lossCondition.effect} />
     </div>
@@ -128,7 +124,6 @@
           class="input"
           type="text"
           placeholder="Name"
-          tabindex="1"
           bind:value={adversary.nameLossEscalation.escalation.name} />
       </div>
     </div>
@@ -138,7 +133,6 @@
         elementType="textarea"
         classNames="is-small"
         placeholder="Effect"
-        tabindex="1"
         validAutoCompleteValues={iconValuesSorted}
         bind:value={adversary.nameLossEscalation.escalation.effect} />
     </div>

--- a/src/routes/aspect/aspect-effects.svelte
+++ b/src/routes/aspect/aspect-effects.svelte
@@ -92,7 +92,6 @@
             class="input"
             type="text"
             placeholder="Name"
-            tabindex="1"
             bind:value={rule.name} />
         </div>
         <button class="button is-warning is-light" on:click={removeSpecialRule(i)}>Remove</button>
@@ -107,8 +106,7 @@
   {/each}
   <div class="field">
     <div class="control">
-      <button class="button is-primary is-light" tabindex="1" on:click={addSpecialRule}
-        >Add Special Rule</button>
+      <button class="button is-primary is-light" on:click={addSpecialRule}>Add Special Rule</button>
     </div>
   </div>
   {#each aspect.aspectEffects.innatePowers.powers as power, i (power.id)}
@@ -121,7 +119,6 @@
             id={`powerName${i}`}
             class="input"
             type="text"
-            tabindex="1"
             placeholder="Power Name"
             bind:value={power.name} />
         </div>
@@ -195,7 +192,6 @@
               id={`powerRange${i}`}
               class="input"
               type="text"
-              tabindex="1"
               placeholder="Range"
               bind:value={power.range} />
           </div>
@@ -227,7 +223,6 @@
             id={`power${i}levelThreshold${j}`}
             class="input is-small"
             type="text"
-            tabindex="1"
             placeholder="Threshold"
             bind:value={level.threshold} />
         </div>

--- a/src/routes/aspect/name-replacements.svelte
+++ b/src/routes/aspect/name-replacements.svelte
@@ -70,7 +70,6 @@
             class="input"
             type="text"
             placeholder="Name"
-            tabindex="1"
             bind:value={aspect.nameReplacements.aspectName} />
         </div>
       </div>
@@ -85,7 +84,6 @@
           class="input"
           type="text"
           placeholder="ie. Replaces Special Rule"
-          tabindex="1"
           bind:value={aspect.nameReplacements.aspectRelacement} />
       </div>
     </div>
@@ -99,7 +97,6 @@
           class="input"
           type="text"
           placeholder="ie. The Name of a Spirit's Special Rule"
-          tabindex="1"
           bind:value={aspect.nameReplacements.rulesReplaced} />
       </div>
     </div>
@@ -141,7 +138,6 @@
             class="input"
             type="text"
             placeholder="The Name of a Spirit"
-            tabindex="1"
             bind:value={aspect.nameReplacements.spiritName} />
         </div>
       </div>

--- a/src/routes/custom-icons.svelte
+++ b/src/routes/custom-icons.svelte
@@ -92,7 +92,7 @@
   {/each}
   <div class="field is-flex is-justify-content-right">
     <div class="control">
-      <button class="button is-primary is-light is-small" tabindex="1" on:click={addCustomIcon}
+      <button class="button is-primary is-light is-small" on:click={addCustomIcon}
         >Add Custom Icon</button>
     </div>
   </div>

--- a/src/routes/lib.js
+++ b/src/routes/lib.js
@@ -151,9 +151,12 @@ export const addLevel = (
   levelEffect = "",
   levelLong = false
 ) => {
-
-  var focusId = "power" + powerIndex + "levelThreshold" + spiritBoard.innatePowers.powers[powerIndex].levels.length;
-  console.log(focusId)
+  var focusId =
+    "power" +
+    powerIndex +
+    "levelThreshold" +
+    spiritBoard.innatePowers.powers[powerIndex].levels.length;
+  console.log(focusId);
   spiritBoard.innatePowers.powers[powerIndex].levels.push({
     id: spiritBoard.innatePowers.powers[powerIndex].levels.length,
     threshold: levelThreshold,
@@ -200,66 +203,69 @@ export const takeScreenshot = (frame, fileNames, elementNamesInIframe) => {
   });
 };
 
-
 export const nextNode = (event) => {
-  if (event.key == 'Enter'){
+  if (event.key == "Enter") {
     var currentID = event.target.id;
-    var numlessID = currentID.replace(/\d/g, "")
+    var numlessID = currentID.replace(/\d/g, "");
     var focusID = "";
     var regFindNumbers = /^\d+|\d+\b|\d+(?=\w)/g;
-    var numMatches = currentID.match(regFindNumbers)
+    var numMatches = currentID.match(regFindNumbers);
 
-    switch(numlessID){
+    switch (numlessID) {
       //Special Rule
-      case 'ruleNameInput':
-        focusID = currentID.replace('Name','Effect')
+      case "ruleNameInput":
+        focusID = currentID.replace("Name", "Effect");
         break;
       //Growth
-      case 'growthSetGroupAction':
-        focusID = currentID.replace(/\d+$/, function(m) { return parseInt(m) + 1; })
-        if(document.getElementById(focusID) == null){
-          focusID = currentID.replace('Action','AddAction')
-          focusID = focusID.slice(0,-1)  
+      case "growthSetGroupAction":
+        focusID = currentID.replace(/\d+$/, function (m) {
+          return parseInt(m) + 1;
+        });
+        if (document.getElementById(focusID) == null) {
+          focusID = currentID.replace("Action", "AddAction");
+          focusID = focusID.slice(0, -1);
         }
         break;
       //Presence Tracks
-      case 'energybuilder':
-      case 'playsbuilder':
-        focusID= currentID.replace(/(\d+)+/g, function(match, number) {
-          return parseInt(number)+1;
+      case "energybuilder":
+      case "playsbuilder":
+        focusID = currentID.replace(/(\d+)+/g, function (match, number) {
+          return parseInt(number) + 1;
         });
-        if(document.getElementById(focusID) == null){
-          focusID = currentID +'add'
+        if (document.getElementById(focusID) == null) {
+          focusID = currentID + "add";
         }
         break;
       //Innate Powers
-      case 'powerlevelThreshold':
-        focusID = currentID.replace('Threshold','Effect')  
+      case "powerlevelThreshold":
+        focusID = currentID.replace("Threshold", "Effect");
         break;
-      case 'powerlevelEffect':
-        focusID = currentID.replace('Effect','Threshold')
-        focusID = focusID.replace(/\d+$/, function(m) { return parseInt(m) + 1; })
-        if(document.getElementById(focusID) == null){
-          focusID = 'power'+numMatches[0]+'addLevel'
+      case "powerlevelEffect":
+        focusID = currentID.replace("Effect", "Threshold");
+        focusID = focusID.replace(/\d+$/, function (m) {
+          return parseInt(m) + 1;
+        });
+        if (document.getElementById(focusID) == null) {
+          focusID = "power" + numMatches[0] + "addLevel";
         }
         break;
-      case 'powerName':
-        focusID = 'powerRange'+numMatches[0];
+      case "powerName":
+        focusID = "powerRange" + numMatches[0];
         break;
-      case 'powerRange':
-        focusID = 'powerTarget'+numMatches[0];
+      case "powerRange":
+        focusID = "powerTarget" + numMatches[0];
         break;
-      case 'powerTarget':
-        focusID = 'powerNote'+numMatches[0];
+      case "powerTarget":
+        focusID = "powerNote" + numMatches[0];
         break;
-      case 'powerNote':
-        focusID = 'power'+numMatches[0]+'levelThreshold0';
-        if(document.getElementById(focusID) == null){
-          focusID = 'power'+numMatches[0]+'addLevel'
+      case "powerNote":
+        focusID = "power" + numMatches[0] + "levelThreshold0";
+        if (document.getElementById(focusID) == null) {
+          focusID = "power" + numMatches[0] + "addLevel";
         }
         break;
     }
 
     document.getElementById(focusID).focus();
   }
-}
+};

--- a/src/routes/power-cards/power-card.svelte
+++ b/src/routes/power-cards/power-card.svelte
@@ -130,7 +130,6 @@
             id={`powerName${i}`}
             class="input"
             type="text"
-            tabindex="1"
             placeholder="Power Name"
             bind:value={card.name} />
         </div>
@@ -147,7 +146,6 @@
             class="input"
             style="width:3rem; text-align:center;"
             type="text"
-            tabindex="1"
             placeholder="Cost"
             bind:value={card.cost} />
         </div>
@@ -244,7 +242,6 @@
             id={`powerRange${i}`}
             class="input"
             type="text"
-            tabindex="1"
             placeholder="Range"
             bind:value={card.range} />
         </div>
@@ -308,7 +305,6 @@
             class="input is-small mr-3"
             style="width:35%"
             type="text"
-            tabindex="1"
             placeholder="Elemental Conditions"
             bind:value={card.thresholdCondition} />
           <label class="label is-unselectable mr-2 mb-0 mt-1" style="min-width:7rem" for=""
@@ -317,7 +313,6 @@
             id={`powerCustomText${i}`}
             class="input is-small"
             type="text"
-            tabindex="1"
             placeholder="use if an alternative to 'IF YOU HAVE' is desired"
             bind:value={card.thresholdText} />
         </div>
@@ -342,7 +337,6 @@
             id={`cardArtist${i}`}
             class="input is-small"
             type="text"
-            tabindex="1"
             placeholder="Artist"
             bind:value={card.cardArtist} />
         </div>

--- a/src/routes/spirit-board-back/name-art-lore.svelte
+++ b/src/routes/spirit-board-back/name-art-lore.svelte
@@ -57,7 +57,6 @@
           class="input"
           type="text"
           placeholder="Name"
-          tabindex="1"
           bind:value={spiritBoardBack.nameImage.name} />
       </div>
     </div>
@@ -108,7 +107,6 @@
         class="textarea"
         type="text"
         placeholder="Name"
-        tabindex="1"
         bind:value={spiritBoardBack.lore.loreText} />
     </div>
   </div>

--- a/src/routes/spirit-board-back/setup-playstyle-complexity-powers.svelte
+++ b/src/routes/spirit-board-back/setup-playstyle-complexity-powers.svelte
@@ -46,7 +46,6 @@
         elementType="textarea"
         classNames="is-small"
         placeholder="Effect"
-        tabindex="1"
         validAutoCompleteValues={iconValuesSorted}
         bind:value={spiritBoardBack.setup.setupText} />
     </div>
@@ -62,7 +61,6 @@
         elementType="textarea"
         classNames="is-small"
         placeholder="Effect"
-        tabindex="1"
         validAutoCompleteValues={iconValuesSorted}
         bind:value={spiritBoardBack.playStyle.playStyleText} />
     </div>
@@ -79,7 +77,6 @@
           class="input"
           type="text"
           placeholder="Complexity Description"
-          tabindex="1"
           bind:value={spiritBoardBack.complexity.complexityDescriptor} />
       </div>
       <div class="control" style="width:30%; min-width:2rem;">
@@ -88,7 +85,6 @@
           class="input"
           type="text"
           placeholder="Complexity Value (1-10)"
-          tabindex="1"
           bind:value={spiritBoardBack.complexity.complexityValue} />
       </div>
     </div>
@@ -110,7 +106,6 @@
             class="input"
             type="text"
             placeholder="Offense Value (1-10)"
-            tabindex="1"
             bind:value={spiritBoardBack.summary.offenseValue} />
         </div>
       </div>
@@ -127,7 +122,6 @@
             class="input"
             type="text"
             placeholder="Control Value (1-10)"
-            tabindex="1"
             bind:value={spiritBoardBack.summary.controlValue} />
         </div>
       </div>
@@ -144,7 +138,6 @@
             class="input"
             type="text"
             placeholder="Fear Value (1-10)"
-            tabindex="1"
             bind:value={spiritBoardBack.summary.fearValue} />
         </div>
       </div>
@@ -161,7 +154,6 @@
             class="input"
             type="text"
             placeholder="Defense Value (1-10)"
-            tabindex="1"
             bind:value={spiritBoardBack.summary.defenseValue} />
         </div>
       </div>
@@ -178,7 +170,6 @@
             class="input"
             type="text"
             placeholder="Utility Value (1-10)"
-            tabindex="1"
             bind:value={spiritBoardBack.summary.utilityValue} />
         </div>
       </div>
@@ -196,7 +187,6 @@
             style="width:100%; min-width:20rem;"
             type="text"
             placeholder="Uses tokens/icons ie. 'badlands,wilds'"
-            tabindex="1"
             bind:value={spiritBoardBack.summary.usesTokens} />
         </div>
       </div>

--- a/src/routes/spirit-board/growth.svelte
+++ b/src/routes/spirit-board/growth.svelte
@@ -247,7 +247,6 @@
               id={`growthSetChoice${i}`}
               class="input"
               type="text"
-              tabindex="1"
               placeholder="Growth Set Choice ie. (PICK ONE OF)"
               bind:value={growthSet.choiceText} />
           </div>
@@ -348,7 +347,6 @@
                 <button
                   id={`growthSet${i}Group${j}AddAction`}
                   class="button is-primary is-light is-small row-button"
-                  tabindex="1"
                   on:click={addGrowthAction(i, j)}>Add Growth Action</button>
               </div>
             </div>
@@ -359,7 +357,6 @@
             <div class="control">
               <button
                 class="button is-primary is-light is-small row-button"
-                tabindex="1"
                 on:click={addGrowthGroup(i)}>Add Growth Group</button>
             </div>
           </div>
@@ -370,10 +367,8 @@
   {#if spiritBoard.growth.useGrowthSets}
     <div class="field">
       <div class="control">
-        <button
-          class="button is-primary is-light is-small row-button"
-          tabindex="1"
-          on:click={addGrowthSet}>Add Growth Set</button>
+        <button class="button is-primary is-light is-small row-button" on:click={addGrowthSet}
+          >Add Growth Set</button>
       </div>
     </div>
   {/if}

--- a/src/routes/spirit-board/growth.svelte
+++ b/src/routes/spirit-board/growth.svelte
@@ -137,36 +137,37 @@
 	} */
 
   function onKeyDown(e) {
-    console.log('onkeydown')
-		 if(e.keyCode==13) {
-      growthActionBuilderID = e.target.id
-      console.log('Builder ID = '+growthActionBuilderID)
-		 }
-	}
+    console.log("onkeydown");
+    if (e.keyCode == 13) {
+      growthActionBuilderID = e.target.id;
+      console.log("Builder ID = " + growthActionBuilderID);
+    }
+  }
 
   // function updateGrowthActionLocal(setIndex, groupIndex, actionIndex) {
   //   updateGrowthAction(setIndex, groupIndex, actionIndex);
   // }
 
   function updateGrowthActionLocal(setIndex, groupIndex, actionIndex) {
-    var newGrowthActionText = spiritBoard.growth.growthSets[setIndex].growthGroups[groupIndex].growthActions[actionIndex].effect;
-    var templateGrowthID = 's'+setIndex+'g'+groupIndex+'a'+actionIndex;
-    var previewFrame = document.getElementById("preview-iframe").contentWindow
-    console.log('Rewriting Growth Node ID: '+templateGrowthID)
-    
-    // Check growth height
-    var growthPanel = previewFrame.document.getElementsByTagName("growth")[0]
-    var growthHeight = growthPanel.offsetHeight
+    var newGrowthActionText =
+      spiritBoard.growth.growthSets[setIndex].growthGroups[groupIndex].growthActions[actionIndex]
+        .effect;
+    var templateGrowthID = "s" + setIndex + "g" + groupIndex + "a" + actionIndex;
+    var previewFrame = document.getElementById("preview-iframe").contentWindow;
+    console.log("Rewriting Growth Node ID: " + templateGrowthID);
 
-    // Try to write a new node    
-   
+    // Check growth height
+    var growthPanel = previewFrame.document.getElementsByTagName("growth")[0];
+    var growthHeight = growthPanel.offsetHeight;
+
+    // Try to write a new node
+
     var growthActionTest = "";
     try {
       growthActionTest = previewFrame.writeGrowthAction(newGrowthActionText);
-    }
-    catch(err) {
-      growthActionTest = previewFrame.writeGrowthAction('custom(error! check syntax)');
-      console.log('Malformed growth option, try again')
+    } catch (err) {
+      growthActionTest = previewFrame.writeGrowthAction("custom(error! check syntax)");
+      console.log("Malformed growth option, try again");
     }
     growthActionTest = previewFrame.replaceIcon(growthActionTest);
 
@@ -176,14 +177,14 @@
     const newNode = placeholder.firstElementChild;
 
     // Transfer new node into preview
-    var findGrowth = previewFrame.document.getElementById(templateGrowthID)
-    findGrowth.innerHTML = newNode.innerHTML
+    var findGrowth = previewFrame.document.getElementById(templateGrowthID);
+    findGrowth.innerHTML = newNode.innerHTML;
 
-    // If new growth panel is larger, re-run    
-    var newGrowthHeight = growthPanel.offsetHeight
-    if(newGrowthHeight > growthHeight){
-      console.log('Recommend Re-running the whole board (click "Update Preview")')
-      document.getElementById('updateButton').classList.add("is-flashy");
+    // If new growth panel is larger, re-run
+    var newGrowthHeight = growthPanel.offsetHeight;
+    if (newGrowthHeight > growthHeight) {
+      console.log('Recommend Re-running the whole board (click "Update Preview")');
+      document.getElementById("updateButton").classList.add("is-flashy");
     }
   }
 
@@ -343,9 +344,8 @@
                   <button
                     class="button is-warning is-light row-button"
                     on:click={updateGrowthActionLocal(i, j, k)}>&#x21bb;</button>
-                  <button
-                    class="button is-light row-button"
-                    on:click={removeGrowthAction(i, j, k)}>Remove</button>
+                  <button class="button is-light row-button" on:click={removeGrowthAction(i, j, k)}
+                    >Remove</button>
                 </div>
               {/each}
               <div class="control">

--- a/src/routes/spirit-board/growth.svelte
+++ b/src/routes/spirit-board/growth.svelte
@@ -2,10 +2,6 @@
   import * as Lib from "../lib";
   import AutoComplete from "$lib/auto-complete/index.svelte";
   import { growthValuesSorted } from "$lib/auto-complete/autoCompleteValues";
-  import PreviewFrame from "$lib/preview-frame.svelte";
-  // import {updateGrowthAction} from "./index.svelte"
-
-  let previewFrame;
 
   function useGrowthSets() {
     spiritBoard.growth.useGrowthSets = true;
@@ -139,7 +135,7 @@
   function onKeyDown(e) {
     console.log("onkeydown");
     if (e.keyCode == 13) {
-      growthActionBuilderID = e.target.id;
+      const growthActionBuilderID = e.target.id;
       console.log("Builder ID = " + growthActionBuilderID);
     }
   }

--- a/src/routes/spirit-board/index.svelte
+++ b/src/routes/spirit-board/index.svelte
@@ -517,7 +517,7 @@
     setBoardValues(spiritBoard);
     previewFrame.copyHTMLFrom(frame.contentDocument, additionalScripts());
     previewFrame.startMain();
-    document.getElementById('updateButton').classList.remove("is-flashy");
+    document.getElementById("updateButton").classList.remove("is-flashy");
   }
 
   function handleTextFileInput(event) {
@@ -593,7 +593,7 @@
   }
 
   async function downloadTTSJSON() {
-    var previewFrameDoc = document.getElementById("preview-iframe").contentWindow.document
+    var previewFrameDoc = document.getElementById("preview-iframe").contentWindow.document;
     const board = previewFrameDoc.querySelectorAll("board")[0];
     const boardRect = board.getBoundingClientRect();
 
@@ -815,7 +815,6 @@
     const elementNamesInIframe = ["board"];
     previewFrame.takeScreenshot(fileNames, elementNamesInIframe);
   }
-
 </script>
 
 <h5 class="title is-5 mb-0 no-anchor">Spirit Board Play Side</h5>
@@ -851,7 +850,8 @@
   <button class="button is-success  mr-1" on:click={exportSpiritBoard}> Save </button>
   <button class="button is-success  mr-1" on:click={screenshotSetUp}>Download Image</button>
   <button class="button is-success  mr-1" on:click={downloadTTSJSON}>Export TTS file</button>
-  <button class="button is-warning  mr-1" id = "updateButton" on:click={reloadPreview}>Update Preview</button>
+  <button class="button is-warning  mr-1" id="updateButton" on:click={reloadPreview}
+    >Update Preview</button>
   <button class="button is-warning mr-1" on:click={previewFrame.toggleSize}
     >Toggle Board Size</button>
   <button class="button is-danger mr-1" on:click={clearAllFields}>Clear All Fields</button>

--- a/src/routes/spirit-board/innate-powers.svelte
+++ b/src/routes/spirit-board/innate-powers.svelte
@@ -8,19 +8,19 @@
   function setSpeedTextbox(powerSpeed, innatePower) {
     innatePower.speed = powerSpeed;
     spiritBoard = spiritBoard;
-    var templateID = 'ip'+innatePower.id;
-    var previewFrame = document.getElementById("preview-iframe").contentWindow
-    var findPowerSpeed = previewFrame.document.getElementById(templateID)
-    findPowerSpeed.removeAttribute('class')
-    findPowerSpeed.setAttribute('class',powerSpeed.toLowerCase());
+    var templateID = "ip" + innatePower.id;
+    var previewFrame = document.getElementById("preview-iframe").contentWindow;
+    var findPowerSpeed = previewFrame.document.getElementById(templateID);
+    findPowerSpeed.removeAttribute("class");
+    findPowerSpeed.setAttribute("class", powerSpeed.toLowerCase());
   }
 
   function setTargetTextbox(targetTitle, innatePower) {
     innatePower.targetTitle = targetTitle;
     spiritBoard = spiritBoard;
-    var templateID = 'ip'+innatePower.id+'targettitle';
-    var previewFrame = document.getElementById("preview-iframe").contentWindow
-    var findTargetTitle = previewFrame.document.getElementById(templateID)
+    var templateID = "ip" + innatePower.id + "targettitle";
+    var previewFrame = document.getElementById("preview-iframe").contentWindow;
+    var findTargetTitle = previewFrame.document.getElementById(templateID);
     findTargetTitle.innerHTML = targetTitle;
   }
 
@@ -56,23 +56,27 @@
 
   function updateInnatePowerThreshold(level, ID) {
     var newIPThresholdText = level.threshold;
-    if (newIPThresholdText){
+    if (newIPThresholdText) {
       var templateInnatePowerThresholdID = ID;
-      var previewFrame = document.getElementById("preview-iframe").contentWindow
-      
-      // Find node in Template
-      var findIPThreshold = previewFrame.document.getElementById(templateInnatePowerThresholdID)
-      if(findIPThreshold){
-        console.log('Rewriting Innate Power ID: '+templateInnatePowerThresholdID + ' with ' + newIPThresholdText)
+      var previewFrame = document.getElementById("preview-iframe").contentWindow;
 
-        // Try to write a new node    
+      // Find node in Template
+      var findIPThreshold = previewFrame.document.getElementById(templateInnatePowerThresholdID);
+      if (findIPThreshold) {
+        console.log(
+          "Rewriting Innate Power ID: " +
+            templateInnatePowerThresholdID +
+            " with " +
+            newIPThresholdText
+        );
+
+        // Try to write a new node
         var newIPThreshold = "";
         try {
           newIPThreshold = previewFrame.writeInnateThreshold(newIPThresholdText);
-        }
-        catch(err) {
-          newIPThreshold = previewFrame.getPresenceNodeHtml('1-water');
-          console.log('Malformed growth option, try again')
+        } catch (err) {
+          newIPThreshold = previewFrame.getPresenceNodeHtml("1-water");
+          console.log("Malformed growth option, try again");
         }
         newIPThreshold = previewFrame.replaceIcon(newIPThreshold);
 
@@ -82,8 +86,7 @@
         const newNode = placeholder.firstElementChild;
 
         // update node
-        findIPThreshold.innerHTML = newNode.innerHTML
-
+        findIPThreshold.innerHTML = newNode.innerHTML;
       }
     }
   }
@@ -93,11 +96,10 @@
     document.getElementById(nodeID).select();
   }
 
-  function nextNode(event){
-    console.log('next node')
-    Lib.nextNode(event)
+  function nextNode(event) {
+    console.log("next node");
+    Lib.nextNode(event);
   }
-
 </script>
 
 <h6
@@ -235,7 +237,10 @@
         validAutoCompleteValues={iconValuesSorted}
         bind:value={innatePower.note} />
     </div>
-    <button class="button is-primary is-light is-small" id={`power${i}addLevel`} on:click={addLevel(i)}>Add Level</button>
+    <button
+      class="button is-primary is-light is-small"
+      id={`power${i}addLevel`}
+      on:click={addLevel(i)}>Add Level</button>
     {#each innatePower.levels as level, j (level.id)}
       <div class="is-flex is-flex-direction-row is-flex-wrap-nowrap">
         <div class="control">
@@ -246,7 +251,7 @@
             tabindex="1"
             placeholder="Threshold"
             on:focus={selectNode}
-            on:blur={updateInnatePowerThreshold(level,`ip${i}L${j}t`)}
+            on:blur={updateInnatePowerThreshold(level, `ip${i}L${j}t`)}
             on:keyup={nextNode}
             bind:value={level.threshold} />
         </div>

--- a/src/routes/spirit-board/innate-powers.svelte
+++ b/src/routes/spirit-board/innate-powers.svelte
@@ -135,7 +135,6 @@
             id={`powerName${i}`}
             class="input"
             type="text"
-            tabindex="1"
             placeholder="Power Name"
             on:keyup={nextNode}
             on:focus={selectNode}
@@ -211,7 +210,6 @@
               id={`powerRange${i}`}
               class="input"
               type="text"
-              tabindex="1"
               placeholder="Range"
               on:keyup={nextNode}
               on:focus={selectNode}
@@ -248,7 +246,6 @@
             id={`power${i}levelThreshold${j}`}
             class="input is-small"
             type="text"
-            tabindex="1"
             placeholder="Threshold"
             on:focus={selectNode}
             on:blur={updateInnatePowerThreshold(level, `ip${i}L${j}t`)}

--- a/src/routes/spirit-board/presence-tracks.svelte
+++ b/src/routes/spirit-board/presence-tracks.svelte
@@ -18,7 +18,7 @@
       }, 100);
     }
     spiritBoard = spiritBoard;
-    insertTemplatePresenceNode(index,'energy')
+    insertTemplatePresenceNode(index, "energy");
   }
 
   function insertPlaysTrackNode(index) {
@@ -34,18 +34,24 @@
       }, 100);
     }
     spiritBoard = spiritBoard;
-    insertTemplatePresenceNode(index,'card')
+    insertTemplatePresenceNode(index, "card");
   }
 
-  function insertTemplatePresenceNode(index,type){
-    var previewFrame = document.getElementById("preview-iframe").contentWindow
-    var findPresenceNode = previewFrame.document.getElementById(type+index)
-    var newPresenceNode = previewFrame.getPresenceNodeHtml('custom(new presence node)',false,index,type,type=='energy');
+  function insertTemplatePresenceNode(index, type) {
+    var previewFrame = document.getElementById("preview-iframe").contentWindow;
+    var findPresenceNode = previewFrame.document.getElementById(type + index);
+    var newPresenceNode = previewFrame.getPresenceNodeHtml(
+      "custom(new presence node)",
+      false,
+      index,
+      type,
+      type == "energy"
+    );
     const placeholder = document.createElement("td");
     placeholder.innerHTML = newPresenceNode;
-    console.log(placeholder)
-    findPresenceNode.parentElement.after(placeholder)
-    previewFrame.updatePresenceNodeIDs()
+    console.log(placeholder);
+    findPresenceNode.parentElement.after(placeholder);
+    previewFrame.updatePresenceNodeIDs();
   }
 
   function removeEnergyTrackNode(index) {
@@ -54,7 +60,7 @@
       node.id = i;
     });
     spiritBoard = spiritBoard;
-    removeTemplatePresenceNode('energy'+index)
+    removeTemplatePresenceNode("energy" + index);
   }
 
   function removePlaysTrackNode(index) {
@@ -63,52 +69,64 @@
       node.id = i;
     });
     spiritBoard = spiritBoard;
-    removeTemplatePresenceNode('card'+index)
+    removeTemplatePresenceNode("card" + index);
   }
 
-  function removeTemplatePresenceNode(templatePresenceNodeID){
-    var previewFrame = document.getElementById("preview-iframe").contentWindow
-    var findPresenceNode = previewFrame.document.getElementById(templatePresenceNodeID)
-    findPresenceNode.parentElement.remove()
-    previewFrame.updatePresenceNodeIDs()
+  function removeTemplatePresenceNode(templatePresenceNodeID) {
+    var previewFrame = document.getElementById("preview-iframe").contentWindow;
+    var findPresenceNode = previewFrame.document.getElementById(templatePresenceNodeID);
+    findPresenceNode.parentElement.remove();
+    previewFrame.updatePresenceNodeIDs();
   }
 
   function updatePresenceNodeLocal(index, type) {
     //this code works but has an issue with the first node, which is used to modify the spacing...perhaps i should change that spacing instead.
 
     var newPresenceNodeText = "";
-    var templatePresenceNodeID = type+index;
+    var templatePresenceNodeID = type + index;
     switch (type) {
-      case 'energy': 
-        newPresenceNodeText = spiritBoard.presenceTrack.energyNodes[index].effect
+      case "energy":
+        newPresenceNodeText = spiritBoard.presenceTrack.energyNodes[index].effect;
         break;
-      case 'card':
-        newPresenceNodeText = spiritBoard.presenceTrack.playsNodes[index].effect
+      case "card":
+        newPresenceNodeText = spiritBoard.presenceTrack.playsNodes[index].effect;
         break;
     }
-    var previewFrame = document.getElementById("preview-iframe").contentWindow
-    console.log('Rewriting Presence Node ID: '+templatePresenceNodeID)
-    console.log('new node: '+newPresenceNodeText)
-    
+    var previewFrame = document.getElementById("preview-iframe").contentWindow;
+    console.log("Rewriting Presence Node ID: " + templatePresenceNodeID);
+    console.log("new node: " + newPresenceNodeText);
+
     // Find node in Template
-    var findPresenceNode = previewFrame.document.getElementById(templatePresenceNodeID)
-    var isFirst = findPresenceNode.classList.contains('first');
-    var hasEnergyRing = findPresenceNode.getElementsByTagName('energy-icon')[0] !== undefined ? true : false;
-    console.log('is first  '+isFirst)
-    console.log('has energy ring '+hasEnergyRing)
+    var findPresenceNode = previewFrame.document.getElementById(templatePresenceNodeID);
+    var isFirst = findPresenceNode.classList.contains("first");
+    var hasEnergyRing =
+      findPresenceNode.getElementsByTagName("energy-icon")[0] !== undefined ? true : false;
+    console.log("is first  " + isFirst);
+    console.log("has energy ring " + hasEnergyRing);
 
     // Check growth height
-    var presenceTrackPanel = previewFrame.document.getElementsByTagName("presence-tracks")[0]
-    var presenceTrackHeight = presenceTrackPanel.getElementsByTagName("tbody")[0].offsetHeight
+    var presenceTrackPanel = previewFrame.document.getElementsByTagName("presence-tracks")[0];
+    var presenceTrackHeight = presenceTrackPanel.getElementsByTagName("tbody")[0].offsetHeight;
 
-    // Try to write a new node    
+    // Try to write a new node
     var newPresenceNode = "";
     try {
-      newPresenceNode = previewFrame.getPresenceNodeHtml(newPresenceNodeText,isFirst,index,type,hasEnergyRing);
-    }
-    catch(err) {
-      newPresenceNode = previewFrame.getPresenceNodeHtml('custom(error! check syntax)',isFirst,index,type,hasEnergyRing);
-      console.log('Malformed growth option, try again')
+      newPresenceNode = previewFrame.getPresenceNodeHtml(
+        newPresenceNodeText,
+        isFirst,
+        index,
+        type,
+        hasEnergyRing
+      );
+    } catch (err) {
+      newPresenceNode = previewFrame.getPresenceNodeHtml(
+        "custom(error! check syntax)",
+        isFirst,
+        index,
+        type,
+        hasEnergyRing
+      );
+      console.log("Malformed growth option, try again");
     }
     newPresenceNode = previewFrame.replaceIcon(newPresenceNode);
 
@@ -116,22 +134,22 @@
     const placeholder = document.createElement("div");
     placeholder.innerHTML = newPresenceNode;
     const newNode = placeholder.firstElementChild;
-    console.log(newNode)
+    console.log(newNode);
 
     // update node
-    findPresenceNode.innerHTML = newNode.innerHTML
+    findPresenceNode.innerHTML = newNode.innerHTML;
 
-    // If new panel is larger, re-run    
-    var newPresenceTrackHeight = presenceTrackPanel.getElementsByTagName("tbody")[0].offsetHeight
-    if(newPresenceTrackHeight !== presenceTrackHeight){
-      console.log('Recommend Re-running the whole board (click "Update Preview")')
-      document.getElementById('updateButton').classList.add("is-flashy");
+    // If new panel is larger, re-run
+    var newPresenceTrackHeight = presenceTrackPanel.getElementsByTagName("tbody")[0].offsetHeight;
+    if (newPresenceTrackHeight !== presenceTrackHeight) {
+      console.log('Recommend Re-running the whole board (click "Update Preview")');
+      document.getElementById("updateButton").classList.add("is-flashy");
     }
   }
 
-  function nextNode(event){
-    console.log('next node')
-    Lib.nextNode(event)
+  function nextNode(event) {
+    console.log("next node");
+    Lib.nextNode(event);
   }
 
   // function nextNode(event){
@@ -157,7 +175,6 @@
     var nodeID = event.target.id;
     document.getElementById(nodeID).select();
   }
-
 </script>
 
 <h6
@@ -197,7 +214,7 @@
               style="z-index: 2;"
               type="text"
               on:focus={selectNode}
-              on:blur={updatePresenceNodeLocal(i,'energy')}
+              on:blur={updatePresenceNodeLocal(i, "energy")}
               on:keyup={nextNode}
               bind:value={spiritBoard.presenceTrack.energyNodes[i].effect} />
           </div>
@@ -232,7 +249,7 @@
               class="input is-small"
               style="z-index: 2;"
               type="text"
-              on:blur={updatePresenceNodeLocal(i,'card')}
+              on:blur={updatePresenceNodeLocal(i, "card")}
               on:focus={selectNode}
               on:keyup={nextNode}
               bind:value={spiritBoard.presenceTrack.playsNodes[i].effect} />

--- a/src/routes/spirit-board/special-rules.svelte
+++ b/src/routes/spirit-board/special-rules.svelte
@@ -61,7 +61,6 @@
             class="input"
             type="text"
             placeholder="Name"
-            tabindex="1"
             on:focus={selectNode}
             on:keyup={nextNode}
             bind:value={spiritBoard.specialRules.rules[i].name} />
@@ -78,7 +77,7 @@
     {#if i === spiritBoard.specialRules.rules.length - 1}
       <div class="field">
         <div class="control">
-          <button class="button is-primary is-light" tabindex="1" on:click={addSpecialRule}
+          <button class="button is-primary is-light" on:click={addSpecialRule}
             >Add Another Rule</button>
         </div>
       </div>

--- a/src/routes/spirit-board/special-rules.svelte
+++ b/src/routes/spirit-board/special-rules.svelte
@@ -14,16 +14,15 @@
     spiritBoard = Lib.removeSpecialRule(spiritBoard, index);
   }
 
-  function nextNode(event){
-    console.log('next node')
-    Lib.nextNode(event)
+  function nextNode(event) {
+    console.log("next node");
+    Lib.nextNode(event);
   }
 
   function selectNode(event) {
     var nodeID = event.target.id;
     document.getElementById(nodeID).select();
   }
-
 </script>
 
 <h6

--- a/static/template/_global/css/board_front/general.css
+++ b/static/template/_global/css/board_front/general.css
@@ -129,7 +129,7 @@ custom-meeple {
   z-index: -1;
   flex-grow: 1;
   background-repeat: no-repeat;
-  position:relative;
+  position: relative;
 }
 
 #single-line {

--- a/static/template/_global/css/board_front/innate-power.css
+++ b/static/template/_global/css/board_front/innate-power.css
@@ -654,7 +654,8 @@ cost-energy {
 }
 
 .cost-custom > value {
-  text-shadow: -1px 1px 0 #fff, 1px 1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, -1px 0px 0 #fff, 0px 1px 0 #fff, 1px 0px 0 #fff, 0px -1px 0 #fff;
+  text-shadow: -1px 1px 0 #fff, 1px 1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, -1px 0px 0 #fff,
+    0px 1px 0 #fff, 1px 0px 0 #fff, 0px -1px 0 #fff;
 }
 
 cost-energy value,

--- a/static/template/_global/css/board_front/special-rules.css
+++ b/static/template/_global/css/board_front/special-rules.css
@@ -12,7 +12,7 @@ special-rules-container {
   padding-left: 15px;
   padding-right: 8px;
   z-index: 1;
-  position:relative;
+  position: relative;
 }
 
 special-rules-subtitle {

--- a/static/template/_global/js/board_front.js
+++ b/static/template/_global/js/board_front.js
@@ -46,12 +46,12 @@ function addImages(board) {
     const specialRules = board.querySelectorAll("special-rules-container")[0];
     const spiritBorderSize = board.getAttribute("spirit-border-scale");
     const spiritNamePanel = board.querySelectorAll("spirit-name")[0];
-    console.log('here')
-    console.log(spiritBorderSize)
-    spiritNamePanel.style.backgroundImage = `url(${spiritBorder})`
-    borderHeight = spiritBorderSize !== null ? spiritBorderSize : '100px'
-    console.log('here too')
-    spiritNamePanel.style.backgroundSize = `705px ${borderHeight}`
+    console.log("here");
+    console.log(spiritBorderSize);
+    spiritNamePanel.style.backgroundImage = `url(${spiritBorder})`;
+    borderHeight = spiritBorderSize !== null ? spiritBorderSize : "100px";
+    console.log("here too");
+    spiritNamePanel.style.backgroundSize = `705px ${borderHeight}`;
   }
   if (spiritImage) {
     //Image now scales to fill gap. 'imageSize' allows the user to specify what % of the gap to cover
@@ -107,15 +107,16 @@ function buildGrowthPanel() {
           j < childElement.children.length - 1 ? childElement.children[j + 1] : undefined;
 
         newGrowthCellHTML += writeGrowthGroup(
-          childElement.children[j], 
-          setIndex, 
+          childElement.children[j],
+          setIndex,
           groupIndex,
           childElement.title ? currentHeaderIndex : undefined
         );
-        
+
         // Add single border
         if (nextSubElement && nextSubElement.nodeName.toLowerCase() == "growth-group") {
-          newGrowthCellHTML += "<growth-border" + ` header=${currentHeaderIndex}` + "></growth-border>";
+          newGrowthCellHTML +=
+            "<growth-border" + ` header=${currentHeaderIndex}` + "></growth-border>";
           groupIndex += 1;
         }
       }
@@ -129,7 +130,6 @@ function buildGrowthPanel() {
         groupIndex = 0;
         setIndex += 1;
       }
-      
     } else {
       // Not Using Growth Sets
       newGrowthCellHTML += writeGrowthGroup(childElement, setIndex, groupIndex);
@@ -146,14 +146,16 @@ function buildGrowthPanel() {
   board.getElementsByTagName("growth")[0].innerHTML = fullHTML;
 }
 
-function writeGrowthGroup(growthGroup, setIndex=0, groupIndex=0, headerIndex = NaN) {
+function writeGrowthGroup(growthGroup, setIndex = 0, groupIndex = 0, headerIndex = NaN) {
   let debug = false;
 
-  console.log("--Growth Group s"+setIndex+"g"+groupIndex+"--");
-  if(debug){console.log('growthGroup: ' + growthGroup.outerHTML)}
-  
-  let growthGroupHTML = ""
-  
+  console.log("--Growth Group s" + setIndex + "g" + groupIndex + "--");
+  if (debug) {
+    console.log("growthGroup: " + growthGroup.outerHTML);
+  }
+
+  let growthGroupHTML = "";
+
   const tint = growthGroup.getAttribute("tint");
   let tint_text = "";
   if (tint) {
@@ -205,17 +207,29 @@ function writeGrowthGroup(growthGroup, setIndex=0, groupIndex=0, headerIndex = N
 
   const growthActions = growthGroup.getAttribute("values").split(";");
   console.log(growthActions);
-  
+
   for (j = 0; j < growthActions.length; j++) {
-    growthGroupHTML += writeGrowthAction(growthActions[j], setIndex, groupIndex, j, tint_text="");
+    growthGroupHTML += writeGrowthAction(
+      growthActions[j],
+      setIndex,
+      groupIndex,
+      j,
+      (tint_text = "")
+    );
   }
 
   growthGroupHTML += "</growth-group>";
-  
+
   return growthGroupHTML;
 }
 
-function writeGrowthAction(growthAction, setIndex=0, groupIndex=0, actionIndex=0, tint_text=""){
+function writeGrowthAction(
+  growthAction,
+  setIndex = 0,
+  groupIndex = 0,
+  actionIndex = 0,
+  tint_text = ""
+) {
   let debug = false;
   var regExp = /\(([^)]+)\)/;
   var regExpOuterParentheses = /\(\s*(.+)\s*\)/;
@@ -223,23 +237,23 @@ function writeGrowthAction(growthAction, setIndex=0, groupIndex=0, actionIndex=0
 
   let growthActionHTML = "";
   let growthActionType = growthAction.split("(")[0].split("^")[0];
-  let growthActionID = "s"+setIndex+"g"+groupIndex+"a"+actionIndex
-  if (debug) {    
-    console.log("Growth Action "+growthActionID+": " + growthAction);
-    console.log("Growth Action Type: " + growthActionType)
+  let growthActionID = "s" + setIndex + "g" + groupIndex + "a" + actionIndex;
+  if (debug) {
+    console.log("Growth Action " + growthActionID + ": " + growthAction);
+    console.log("Growth Action Type: " + growthActionType);
   }
-  
+
   // Some tools for OR and Presence nodes
   let isOr = false;
   let isPresenceNode = false;
-  
+
   if (growthActionType == "or") {
     console.log("or detected");
     isOr = true;
     let matches = regExpOuterParentheses.exec(growthAction)[1];
     orGrowthActions = matches.split(regExpCommaNoParentheses);
   }
-  
+
   // Check for Presence Node in Growth
   if (growthActionType == "presence-node") {
     let matches = regExpOuterParentheses.exec(growthAction)[1];
@@ -253,30 +267,28 @@ function writeGrowthAction(growthAction, setIndex=0, groupIndex=0, actionIndex=0
   }
 
   // Establish Growth HTML Openers and Closers
-  let growthOpen = "<growth-cell id='"+growthActionID+"'>" + tint_text;
+  let growthOpen = "<growth-cell id='" + growthActionID + "'>" + tint_text;
   let growthTextOpen = "<growth-text>";
   let growthTextClose = "</growth-text></growth-cell>";
   let growthIcons = "";
   let growthText = "";
-  
+
   // Get the Text and Icons for the Growth Action
-  if(isOr){
+  if (isOr) {
     firstAction = getGrowthActionTextAndIcons(orGrowthActions[0]);
     secondAction = getGrowthActionTextAndIcons(orGrowthActions[1]);
-    growthIcons = firstAction[0]
-    growthText = firstAction[1]
-  }else{
+    growthIcons = firstAction[0];
+    growthText = firstAction[1];
+  } else {
     let actionIconsAndText = getGrowthActionTextAndIcons(growthAction);
-    growthIcons = actionIconsAndText[0]
-    growthText = actionIconsAndText[1]
+    growthIcons = actionIconsAndText[0];
+    growthText = actionIconsAndText[1];
   }
-  
+
   //Handle Presence Node
   if (isPresenceNode) {
     growthIcons =
-      '<presence-node class="growth"><ring-icon>' +
-      growthIcons +
-      "</ring-icon></presence-node>";
+      '<presence-node class="growth"><ring-icon>' + growthIcons + "</ring-icon></presence-node>";
     isPresenceNode = false;
   }
 
@@ -288,24 +300,15 @@ function writeGrowthAction(growthAction, setIndex=0, groupIndex=0, actionIndex=0
     isOr = false;
   }
 
-  growthActionHTML = growthOpen + growthIcons + growthTextOpen + growthText + growthTextClose;  
-  return growthActionHTML
+  growthActionHTML = growthOpen + growthIcons + growthTextOpen + growthText + growthTextClose;
+  return growthActionHTML;
 }
 
-function getGrowthActionTextAndIcons(growthAction){
+function getGrowthActionTextAndIcons(growthAction) {
   let debug = true;
   let growthActionType = growthAction.split("(")[0].split("^")[0];
   const terrains = new Set(["wetland", "mountain", "sand", "sands", "jungle"]);
-  const elementNames = new Set([
-    "sun",
-    "moon",
-    "fire",
-    "air",
-    "plant",
-    "water",
-    "earth",
-    "animal"
-  ]);
+  const elementNames = new Set(["sun", "moon", "fire", "air", "plant", "water", "earth", "animal"]);
   var regExp = /\(([^)]+)\)/;
   var regExpOuterParentheses = /\(\s*(.+)\s*\)/;
 
@@ -409,9 +412,7 @@ function getGrowthActionTextAndIcons(growthAction){
             break;
           default:
             gainPowerCardIcon +=
-              "<icon class='" +
-              gainPowerCardType.toLowerCase() +
-              " gain-card-modifier'></icon>";
+              "<icon class='" + gainPowerCardType.toLowerCase() + " gain-card-modifier'></icon>";
             gainPowerCardText = "Gain " + Capitalise(gainPowerCardType) + " Power Card";
         }
         gainPowerCardIcon += "</icon>";
@@ -505,9 +506,7 @@ function getGrowthActionTextAndIcons(growthAction){
       if (scaling_entity || has_custom_text) {
         energyGrowthIcons += "<gain-per><value>" + scaling_value + "</value></gain-per>";
         energyGrowthIcons +=
-          "<gain-per-element><ring-icon>" +
-          customScalingIcon +
-          "</ring-icon></gain-per-element>";
+          "<gain-per-element><ring-icon>" + customScalingIcon + "</ring-icon></gain-per-element>";
         if (x_is_flat) {
           energyGrowthText += " and +" + scaling_value + " more per ";
         } else {
@@ -1195,8 +1194,7 @@ function getGrowthActionTextAndIcons(growthAction){
       let incarnaOptions = matches[1].split(",");
       let incarnaAction = incarnaOptions[0];
       let incarnaRangeOrToken = incarnaOptions[1] !== undefined ? incarnaOptions[1] : 0;
-      let customIncarnaIcon =
-        incarnaOptions[2] !== undefined ? incarnaOptions[2] : "incarna-ember";
+      let customIncarnaIcon = incarnaOptions[2] !== undefined ? incarnaOptions[2] : "incarna-ember";
       switch (incarnaAction) {
         case "move":
           incarnaIcon =
@@ -1227,8 +1225,7 @@ function getGrowthActionTextAndIcons(growthAction){
             '"><icon class="replace-with-incarna no ' +
             incarnaRangeOrToken +
             '"></custom-icon>';
-          incarnaText =
-            "You may Replace " + IconName(incarnaRangeOrToken) + " with your Incarna";
+          incarnaText = "You may Replace " + IconName(incarnaRangeOrToken) + " with your Incarna";
           break;
         case "add-token":
           incarnaIcon =
@@ -1290,12 +1287,7 @@ function getGrowthActionTextAndIcons(growthAction){
         }
       }
       growthIcons =
-        tokenReqOpen +
-        "<token-wrap>" +
-        tokenIcons +
-        "</token-wrap>" +
-        tokenRange +
-        tokenReqClose;
+        tokenReqOpen + "<token-wrap>" + tokenIcons + "</token-wrap>" + tokenRange + tokenReqClose;
       growthText = tokenText;
       break;
     }
@@ -1356,10 +1348,10 @@ function getGrowthActionTextAndIcons(growthAction){
   //Handle Repeats
   if (repeatText) {
     growthIcons = "<repeat-wrapper>" + repeatOpen + growthIcons + "</repeat-wrapper>";
-    growthText = repeatText+growthText
+    growthText = repeatText + growthText;
   }
-  
-  return [growthIcons,growthText];
+
+  return [growthIcons, growthText];
 }
 
 function parseEnergyTrackTags() {
@@ -1420,7 +1412,11 @@ function parseEnergyTrackTags() {
     }
 
     energyHTML +=
-      "<td" + isMiddle + ">" + getPresenceNodeHtml(nodeText, isFirst , i, "energy", addRing) + "</td>";
+      "<td" +
+      isMiddle +
+      ">" +
+      getPresenceNodeHtml(nodeText, isFirst, i, "energy", addRing) +
+      "</td>";
     isFirst = false;
   }
   energyHTML += "</tr>";
@@ -1523,7 +1519,7 @@ function getPresenceNodeHtml(nodeText, first, nodeIndex, trackType, addEnergyRin
   // a ring-icon element inside, so we can add these now.
   presenceNode = document.createElement("presence-node");
   nodeID = trackType + nodeIndex;
-  presenceNode.setAttribute('id',nodeID);
+  presenceNode.setAttribute("id", nodeID);
   ring = document.createElement("ring-icon");
   presenceNode.appendChild(ring);
   // Will be populated with the sub text that will be added at the end
@@ -1927,17 +1923,17 @@ function getPresenceNodeHtml(nodeText, first, nodeIndex, trackType, addEnergyRin
 
 function updatePresenceNodeIDs() {
   const board = document.querySelectorAll("board")[0];
-  console.log(board)
+  console.log(board);
   var presenceTable = document.getElementById("presence-table");
   var energyTrack = board.getElementsByClassName("energy-track")[0];
-  var energyNodes = energyTrack.getElementsByTagName("presence-node")
+  var energyNodes = energyTrack.getElementsByTagName("presence-node");
   var playsTrack = board.getElementsByClassName("plays-track")[0];
-  var playsNodes = playsTrack.getElementsByTagName("presence-node")
+  var playsNodes = playsTrack.getElementsByTagName("presence-node");
   for (i = 0; i < energyNodes.length; i++) {
-    energyNodes[i].id = 'energy'+i;
+    energyNodes[i].id = "energy" + i;
   }
   for (i = 0; i < playsNodes.length; i++) {
-    playsNodes[i].id = 'card'+i;
+    playsNodes[i].id = "card" + i;
   }
 }
 
@@ -2147,7 +2143,7 @@ function setNewEnergyCardPlayTracks(energyHTML, cardPlayHTML) {
   }
 }
 
-function growthHeadersAndTitles(){
+function growthHeadersAndTitles() {
   // Create Headers (if using Subsets)
   var debug = true;
   const board = document.querySelectorAll("board")[0];
@@ -2386,7 +2382,7 @@ function dynamicResizing() {
     }
   }
 
-  growthHeadersAndTitles()
+  growthHeadersAndTitles();
 
   // Final resize (catches really big things that were missed)
   let growthItems = board.getElementsByTagName("growth-cell");
@@ -2783,7 +2779,7 @@ function parseInnatePowers() {
   var innateHTML = board.getElementsByTagName("quick-innate-power");
 
   for (i = 0; i < innateHTML.length; i++) {
-    fullHTML += parseInnatePower(innateHTML[i],i);
+    fullHTML += parseInnatePower(innateHTML[i], i);
   }
   board.getElementsByTagName("innate-powers")[0].innerHTML =
     "<section-title>Innate Powers</section-title><innate-power-container>" +
@@ -2810,14 +2806,21 @@ function parseInnatePowers() {
   }
 }
 
-function parseInnatePower(innatePowerHTML,index) {
+function parseInnatePower(innatePowerHTML, index) {
   var debug = false;
-  var innatePowerID = 'ip'+index
-  var currentPowerHTML = "<innate-power id='"+innatePowerID+"' class='" + innatePowerHTML.getAttribute("speed") + "'>";
+  var innatePowerID = "ip" + index;
+  var currentPowerHTML =
+    "<innate-power id='" +
+    innatePowerID +
+    "' class='" +
+    innatePowerHTML.getAttribute("speed") +
+    "'>";
 
   //Innate Power title
   currentPowerHTML +=
-    "<innate-power-title id='"+innatePowerID+"title'>" +
+    "<innate-power-title id='" +
+    innatePowerID +
+    "title'>" +
     innatePowerHTML.getAttribute("name") +
     "</innate-power-title><info-container><info-title>";
 
@@ -2827,7 +2830,9 @@ function parseInnatePower(innatePowerHTML,index) {
 
   //Innate Power Target Header
   currentPowerHTML +=
-    "<info-title-target id='"+innatePowerID+"targettitle'>" +
+    "<info-title-target id='" +
+    innatePowerID +
+    "targettitle'>" +
     innatePowerHTML.getAttribute("target-title") +
     "</info-title-target></info-title><innate-info>";
 
@@ -2869,24 +2874,28 @@ function parseInnatePower(innatePowerHTML,index) {
   if (noteValue == null || noteValue == "") {
     noteValue = "";
   } else {
-    currentPowerHTML += "<note id='"+innatePowerID+"note'>" + noteValue + "</note>";
+    currentPowerHTML += "<note id='" + innatePowerID + "note'>" + noteValue + "</note>";
   }
 
   //Innate Power Levels and Thresholds
   var currentLevels = innatePowerHTML.getElementsByTagName("level");
   for (j = 0; j < currentLevels.length; j++) {
-    currentPowerHTML += writeInnateLevel(currentLevels[j], innatePowerID+'L'+j)
+    currentPowerHTML += writeInnateLevel(currentLevels[j], innatePowerID + "L" + j);
   }
 
   currentPowerHTML += "</description-container></innate-power>";
   return currentPowerHTML;
 }
 
-function writeInnateLevel(currentLevel, levelID){
+function writeInnateLevel(currentLevel, levelID) {
   var debug = false;
-  if(debug){console.log('writing level')}
-  if(debug){console.log(currentLevel)}
-  var levelHTML = ""
+  if (debug) {
+    console.log("writing level");
+  }
+  if (debug) {
+    console.log(currentLevel);
+  }
+  var levelHTML = "";
   var currentThreshold = currentLevel.getAttribute("threshold");
   var isText = currentLevel.getAttribute("text");
   if (isText != null) {
@@ -2906,20 +2915,24 @@ function writeInnateLevel(currentLevel, levelID){
     // Break the cost into a numeral and element piece (then do error handling to allow switching the order)
     levelHTML += "<level>";
     levelHTML += writeInnateThreshold(currentThreshold, levelID);
-    levelHTML += "<div class='description" + isLong + "' id='"+levelID+"'>";
+    levelHTML += "<div class='description" + isLong + "' id='" + levelID + "'>";
     var currentDescription = currentLevel.innerHTML;
     levelHTML += currentDescription + "</div></level>";
   }
   return levelHTML;
 }
 
-function writeInnateThreshold(currentThreshold, levelID='placeholder'){
+function writeInnateThreshold(currentThreshold, levelID = "placeholder") {
   var debug = false;
   var regExp = /\(([^)]+)\)/;
   var thresholdHTML = "";
-  if(debug){console.log('writing threshold')}
-  if(debug){console.log(currentThreshold)}
-  thresholdHTML += "<threshold id='"+levelID+"t'>";
+  if (debug) {
+    console.log("writing threshold");
+  }
+  if (debug) {
+    console.log(currentThreshold);
+  }
+  thresholdHTML += "<threshold id='" + levelID + "t'>";
   var currentThresholdPieces = currentThreshold.split(",");
   var elementPieces = [];
   var numeralPieces = [];


### PR DESCRIPTION
Setting a tabindex greater than 0, causes that element to be moved to
the beginning of the entire page's tab order, before any elements
with 0 or no tabindex.

This also stops filtering out the lint from svelte about this issue.
    
Reference: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard#avoid_using_tabindex_attribute_greater_than_zero

I'm not sure why this was originally added, but it definitely cause the tab order to be very random. I've taken
a screenshots before and after this change of part of the spirit board page, with the tab order shown (via the accessibility panel in Firefox's Dev Tools).
> Before:
> ![Before](https://user-images.githubusercontent.com/283816/209742376-7336cd05-bb0b-4e69-83ed-4a1d328d4790.png)

> After:
> ![After](https://user-images.githubusercontent.com/283816/209742394-a3742e68-4ba0-4ad1-b8ea-830a13087993.png)

In the before image, you can see that the tab order starts in the middle of the left column (at the start of the special rules) and continues down (skipping the remove buttons). It continues down the left column (at the end of the growth section), skips to a textbox at the end of the presence section, and then continues sporadically through the innate section (skipping all the buttons). Finally, it wraps to the beginning, and has all the elements that were skipped before. 
