### PR TITLE
Fix whitespace in footer.

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -428,16 +428,15 @@
     <span class="is-pulled-right"
       >Code for this project is hosted <a
         href="https://github.com/neubee/spirit-island-builder"
-        target="_blank">here</a>
-      {#if import.meta.env.VITE_COMMIT_SHA != undefined}
+        target="_blank">here</a
+      >{#if import.meta.env.VITE_COMMIT_SHA != undefined}
         &nbsp;(built from
         <a
           href="https://github.com/neubee/spirit-island-builder/commit/{import.meta.env
             .VITE_COMMIT_SHA}"
           target="_blank"
           rel="noreferrer">{import.meta.env.VITE_COMMIT_SHA.substring(0, 8)}</a
-        >)
-      {/if}.</span>
+        >){/if}.</span>
     <br />This is an unofficial website. Interface created by Neubee & Resonant. The Spirit Island
     Builder is adapted from
     <a href="https://github.com/Gudradain/spirit-island-template" target="_blank">HTML template</a>


### PR DESCRIPTION
Follow up to #158. It looks like I missed a linting error, and the fix that was applied missed the subtle interaction of whitespace and conditionals. Based on the changes here to get thing to work, the trick appears to put the `>` of the closing tag at the beginning of the line where the following tag starts.