### PR TITLE
Changed DownloadString to use encodeURIComponent

### DIFF
--- a/src/routes/lib.js
+++ b/src/routes/lib.js
@@ -179,7 +179,7 @@ export const downloadFile = (fileURL, fileName) => {
 };
 
 export const downloadString = (mimeType, fileContent, fileName) => {
-  downloadFile(`${mimeType},${encodeURI(fileContent)}`, fileName);
+  downloadFile(`${mimeType},${encodeURIComponent(fileContent)}`, fileName);
 };
 
 export const takeScreenshot = (frame, fileNames, elementNamesInIframe) => {


### PR DESCRIPTION
This change allows the use of reserved URI Characters consisting of "; / ? : @ & = + $ , #" without potentially Causing a malformed url for downloads.

While trying to create and save an adversary I ran into a bug where pound signs(#) in the comments of the default adversary were causing the save function to download only part of the file, up to the first Pound Sign.
The pound sign in a URL specifically causes issues due to it being an identifier for fragments.

See the bellow documentation on encodeURI not escaping reserved characters
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
And the bellow link for over all structure of URI Requests
https://en.wikipedia.org/wiki/Uniform_Resource_Identifier