### PR TITLE
Get rid of a useless check in `readHTML`.

### DIFF
--- a/src/routes/adversary/index.svelte
+++ b/src/routes/adversary/index.svelte
@@ -89,31 +89,29 @@
   function readHTML(htmlElement) {
     console.log("Loading adversary into form (f=readHTML)");
     //Reads the Template HTML file into the Form
-    if (adversaryFrame) {
-      //Load Adversary Name, Base Difficulty and Flag Image
-      const adversaryHeader = htmlElement.querySelectorAll("quick-adversary")[0];
-      adversary.nameLossEscalation.name = adversaryHeader.getAttribute("name");
-      adversary.nameLossEscalation.baseDif = adversaryHeader.getAttribute("base-difficulty");
-      adversary.nameLossEscalation.flagImg = adversaryHeader.getAttribute("flag-image");
+    //Load Adversary Name, Base Difficulty and Flag Image
+    const adversaryHeader = htmlElement.querySelectorAll("quick-adversary")[0];
+    adversary.nameLossEscalation.name = adversaryHeader.getAttribute("name");
+    adversary.nameLossEscalation.baseDif = adversaryHeader.getAttribute("base-difficulty");
+    adversary.nameLossEscalation.flagImg = adversaryHeader.getAttribute("flag-image");
 
-      //Load Loss Condition
-      const lossConditionHeader = htmlElement.querySelectorAll("loss-condition")[0];
-      adversary.nameLossEscalation.lossCondition.name = lossConditionHeader.getAttribute("name");
-      adversary.nameLossEscalation.lossCondition.effect = lossConditionHeader.getAttribute("rules");
+    //Load Loss Condition
+    const lossConditionHeader = htmlElement.querySelectorAll("loss-condition")[0];
+    adversary.nameLossEscalation.lossCondition.name = lossConditionHeader.getAttribute("name");
+    adversary.nameLossEscalation.lossCondition.effect = lossConditionHeader.getAttribute("rules");
 
-      //Load Escalation
-      const escalationHeader = htmlElement.querySelectorAll("escalation-effect")[0];
-      adversary.nameLossEscalation.escalation.name = escalationHeader.getAttribute("name");
-      adversary.nameLossEscalation.escalation.effect = escalationHeader.getAttribute("rules");
+    //Load Escalation
+    const escalationHeader = htmlElement.querySelectorAll("escalation-effect")[0];
+    adversary.nameLossEscalation.escalation.name = escalationHeader.getAttribute("name");
+    adversary.nameLossEscalation.escalation.effect = escalationHeader.getAttribute("rules");
 
-      //Load Levels
-      for (let i = 0; i < 6; i++) {
-        var HTMLLevel = htmlElement.querySelectorAll("level-" + (i + 1))[0];
-        adversary.levelSummary.levels[i].name = HTMLLevel.getAttribute("name");
-        adversary.levelSummary.levels[i].difficulty = HTMLLevel.getAttribute("difficulty");
-        adversary.levelSummary.levels[i].fearCards = HTMLLevel.getAttribute("fear-cards");
-        adversary.levelSummary.levels[i].effect = HTMLLevel.getAttribute("rules");
-      }
+    //Load Levels
+    for (let i = 0; i < 6; i++) {
+      var HTMLLevel = htmlElement.querySelectorAll("level-" + (i + 1))[0];
+      adversary.levelSummary.levels[i].name = HTMLLevel.getAttribute("name");
+      adversary.levelSummary.levels[i].difficulty = HTMLLevel.getAttribute("difficulty");
+      adversary.levelSummary.levels[i].fearCards = HTMLLevel.getAttribute("fear-cards");
+      adversary.levelSummary.levels[i].effect = HTMLLevel.getAttribute("rules");
     }
   }
 

--- a/src/routes/aspect/index.svelte
+++ b/src/routes/aspect/index.svelte
@@ -162,92 +162,90 @@
   function readHTML(htmlElement) {
     console.log("Loading aspect into form (f=readHTML)");
     //Reads the Template HTML file into the Form
-    if (aspectFrame) {
-      const aspectHTML = htmlElement.querySelectorAll("aspect")[0];
+    const aspectHTML = htmlElement.querySelectorAll("aspect")[0];
 
-      //Profile or Landscape
-      if (aspectHTML.hasAttribute("profile")) {
-        aspect.profile = true;
-      }
-
-      //Read Aspect Name
-      const aspectName = aspectHTML.querySelectorAll("aspect-name")[0];
-      aspect.nameReplacements.aspectName = aspectName.innerHTML.trim();
-
-      //Read Replacement
-      const aspectReplacementHTML = aspectHTML.querySelectorAll("aspect-subtext")[0];
-      if (aspectReplacementHTML) {
-        aspect.nameReplacements.aspectRelacement = aspectReplacementHTML.textContent.split(":")[0];
-        aspect.nameReplacements.rulesReplaced = aspectHTML.querySelectorAll("i")[0].textContent;
-      }
-
-      //Read Complexity
-      const complexityHTML = aspectHTML.querySelectorAll("complexity")[0];
-      if (complexityHTML) {
-        aspect.nameReplacements.complexity = complexityHTML.getAttribute("value");
-      }
-
-      //Read Aspect Back
-      const aspectBackHTML = htmlElement.querySelectorAll("aspect-back")[0];
-      console.log(aspectBackHTML);
-      console.log("^^^^");
-      if (aspectBackHTML) {
-        aspect.nameReplacements.spiritName = aspectBackHTML.getAttribute("spirit-name");
-        aspect.nameReplacements.spiritImage = aspectBackHTML.getAttribute("src");
-        aspect.nameReplacements.hasBack = true;
-      } else {
-        aspect.nameReplacements.hasBack = false;
-      }
-
-      //Read Special Rules
-      const specialRulesNames = aspectHTML.querySelectorAll("special-rules-subtitle");
-      const specialRulesEffects = aspectHTML.querySelectorAll("special-rule");
-      aspect.aspectEffects.specialRules.rules.splice(
-        0,
-        aspect.aspectEffects.specialRules.rules.length
-      ); //Clear the Form first
-      specialRulesNames.forEach((specialRulesName, j) => {
-        aspect.aspectEffects = Lib.addSpecialRule(
-          aspect.aspectEffects,
-          specialRulesName.textContent,
-          specialRulesEffects[j].innerHTML.trim()
-        );
-        aspect = aspect;
-      });
-
-      //Read Innate Powers
-      var innatePowers = htmlElement.querySelectorAll("quick-innate-power");
-      aspect.aspectEffects.innatePowers.powers.splice(
-        0,
-        aspect.aspectEffects.innatePowers.powers.length
-      ); //Clear the Form first
-      if (innatePowers) {
-        innatePowers.forEach((innatePower, k) => {
-          aspect.aspectEffects = Lib.addInnatePower(
-            aspect.aspectEffects,
-            innatePower.getAttribute("name"),
-            innatePower.getAttribute("speed"),
-            innatePower.getAttribute("range"),
-            innatePower.getAttribute("target"),
-            innatePower.getAttribute("target-title"),
-            innatePower.getAttribute("note")
-          );
-          var htmlLevels = innatePower.querySelectorAll("level");
-          htmlLevels.forEach((htmlLevel) => {
-            aspect.aspectEffects = Lib.addLevel(
-              aspect.aspectEffects,
-              k,
-              htmlLevel.getAttribute("threshold"),
-              htmlLevel.textContent.trim(),
-              htmlLevel.hasAttribute("long")
-            );
-          });
-        });
-      }
-
-      console.log("aspect loaded");
-      console.log(aspect);
+    //Profile or Landscape
+    if (aspectHTML.hasAttribute("profile")) {
+      aspect.profile = true;
     }
+
+    //Read Aspect Name
+    const aspectName = aspectHTML.querySelectorAll("aspect-name")[0];
+    aspect.nameReplacements.aspectName = aspectName.innerHTML.trim();
+
+    //Read Replacement
+    const aspectReplacementHTML = aspectHTML.querySelectorAll("aspect-subtext")[0];
+    if (aspectReplacementHTML) {
+      aspect.nameReplacements.aspectRelacement = aspectReplacementHTML.textContent.split(":")[0];
+      aspect.nameReplacements.rulesReplaced = aspectHTML.querySelectorAll("i")[0].textContent;
+    }
+
+    //Read Complexity
+    const complexityHTML = aspectHTML.querySelectorAll("complexity")[0];
+    if (complexityHTML) {
+      aspect.nameReplacements.complexity = complexityHTML.getAttribute("value");
+    }
+
+    //Read Aspect Back
+    const aspectBackHTML = htmlElement.querySelectorAll("aspect-back")[0];
+    console.log(aspectBackHTML);
+    console.log("^^^^");
+    if (aspectBackHTML) {
+      aspect.nameReplacements.spiritName = aspectBackHTML.getAttribute("spirit-name");
+      aspect.nameReplacements.spiritImage = aspectBackHTML.getAttribute("src");
+      aspect.nameReplacements.hasBack = true;
+    } else {
+      aspect.nameReplacements.hasBack = false;
+    }
+
+    //Read Special Rules
+    const specialRulesNames = aspectHTML.querySelectorAll("special-rules-subtitle");
+    const specialRulesEffects = aspectHTML.querySelectorAll("special-rule");
+    aspect.aspectEffects.specialRules.rules.splice(
+      0,
+      aspect.aspectEffects.specialRules.rules.length
+    ); //Clear the Form first
+    specialRulesNames.forEach((specialRulesName, j) => {
+      aspect.aspectEffects = Lib.addSpecialRule(
+        aspect.aspectEffects,
+        specialRulesName.textContent,
+        specialRulesEffects[j].innerHTML.trim()
+      );
+      aspect = aspect;
+    });
+
+    //Read Innate Powers
+    var innatePowers = htmlElement.querySelectorAll("quick-innate-power");
+    aspect.aspectEffects.innatePowers.powers.splice(
+      0,
+      aspect.aspectEffects.innatePowers.powers.length
+    ); //Clear the Form first
+    if (innatePowers) {
+      innatePowers.forEach((innatePower, k) => {
+        aspect.aspectEffects = Lib.addInnatePower(
+          aspect.aspectEffects,
+          innatePower.getAttribute("name"),
+          innatePower.getAttribute("speed"),
+          innatePower.getAttribute("range"),
+          innatePower.getAttribute("target"),
+          innatePower.getAttribute("target-title"),
+          innatePower.getAttribute("note")
+        );
+        var htmlLevels = innatePower.querySelectorAll("level");
+        htmlLevels.forEach((htmlLevel) => {
+          aspect.aspectEffects = Lib.addLevel(
+            aspect.aspectEffects,
+            k,
+            htmlLevel.getAttribute("threshold"),
+            htmlLevel.textContent.trim(),
+            htmlLevel.hasAttribute("long")
+          );
+        });
+      });
+    }
+
+    console.log("aspect loaded");
+    console.log(aspect);
   }
 
   function exportAspect() {

--- a/src/routes/power-cards/index.svelte
+++ b/src/routes/power-cards/index.svelte
@@ -119,35 +119,33 @@
   function readHTML(htmlElement) {
     console.log("Loading power cards into form (f=readHTML)");
     //Reads the Template HTML file into the Form
-    if (cardsFrame) {
-      const powerCardsHTML = htmlElement.querySelectorAll("quick-card");
-      console.log("Loading " + powerCardsHTML.length + " cards...");
+    const powerCardsHTML = htmlElement.querySelectorAll("quick-card");
+    console.log("Loading " + powerCardsHTML.length + " cards...");
 
-      //Clear the form first
-      powerCards.cards.splice(0, powerCards.cards.length); //Clear the Form first
+    //Clear the form first
+    powerCards.cards.splice(0, powerCards.cards.length); //Clear the Form first
 
-      //Iterate through the cards
-      powerCardsHTML.forEach((powerCardHTML) => {
-        addPowerCard(powerCards, powerCardHTML);
-      });
+    //Iterate through the cards
+    powerCardsHTML.forEach((powerCardHTML) => {
+      addPowerCard(powerCards, powerCardHTML);
+    });
 
-      //Custom Icons
-      if (powerCards.demoBoardWasLoaded) {
-        const cardsStyle = htmlElement.querySelectorAll("style")[0];
-        customIcons.icons.splice(0, customIcons.icons.length); //Clear the Form first
-        if (cardsStyle) {
-          const regExp = new RegExp(/(?<=(["']))(?:(?=(\\?))\2.)*?(?=\1)/, "g");
-          let iconList = cardsStyle.textContent.match(regExp);
-          if (iconList) {
-            iconList.forEach((customIcon) => {
-              customIcons = Lib.addCustomIcon(customIcons, customIcon);
-              console.log(customIcon);
-            });
-          }
+    //Custom Icons
+    if (powerCards.demoBoardWasLoaded) {
+      const cardsStyle = htmlElement.querySelectorAll("style")[0];
+      customIcons.icons.splice(0, customIcons.icons.length); //Clear the Form first
+      if (cardsStyle) {
+        const regExp = new RegExp(/(?<=(["']))(?:(?=(\\?))\2.)*?(?=\1)/, "g");
+        let iconList = cardsStyle.textContent.match(regExp);
+        if (iconList) {
+          iconList.forEach((customIcon) => {
+            customIcons = Lib.addCustomIcon(customIcons, customIcon);
+            console.log(customIcon);
+          });
         }
-      } else {
-        console.log("SKIPPING ICON LOAD");
       }
+    } else {
+      console.log("SKIPPING ICON LOAD");
     }
   }
 

--- a/src/routes/spirit-board-back/index.svelte
+++ b/src/routes/spirit-board-back/index.svelte
@@ -122,70 +122,68 @@
   function readHTML(htmlElement) {
     console.log("Loading spirit lore board into form (f=readHTML)");
     //Reads the Template HTML file into the Form
-    if (loreFrame) {
-      const loreBoardHTML = htmlElement.querySelectorAll("board")[0];
+    const loreBoardHTML = htmlElement.querySelectorAll("board")[0];
 
-      //Set Spirit Name
-      const loreName = loreBoardHTML.querySelectorAll("spirit-name")[0];
+    //Set Spirit Name
+    const loreName = loreBoardHTML.querySelectorAll("spirit-name")[0];
 
-      spiritBoardBack.nameImage.name = loreName.innerHTML.trim();
+    spiritBoardBack.nameImage.name = loreName.innerHTML.trim();
 
-      //Set Spirit Image
-      const loreImage = loreBoardHTML.querySelectorAll("img")[0];
-      if (loreImage) {
-        spiritBoardBack.nameImage.img = loreImage.getAttribute("src");
-        var imgScale = loreImage.getAttribute("scale");
-        console.log(imgScale);
-        if (imgScale) {
-          spiritBoardBack.nameImage.scale = imgScale;
+    //Set Spirit Image
+    const loreImage = loreBoardHTML.querySelectorAll("img")[0];
+    if (loreImage) {
+      spiritBoardBack.nameImage.img = loreImage.getAttribute("src");
+      var imgScale = loreImage.getAttribute("scale");
+      console.log(imgScale);
+      if (imgScale) {
+        spiritBoardBack.nameImage.scale = imgScale;
+      }
+    }
+    //Set Lore Description
+    const loreDescription = loreBoardHTML.querySelectorAll("lore-description")[0];
+
+    spiritBoardBack.lore.loreText = loreDescription.innerHTML.trim();
+
+    //Set Lore Setup
+    const loreSetup = loreBoardHTML.querySelectorAll("setup-description")[0];
+    spiritBoardBack.setup.setupText = loreSetup.innerHTML.trim();
+
+    //Set Lore Play Style
+    const lorePlayStyle = loreBoardHTML.querySelectorAll("play-style-description")[0];
+    spiritBoardBack.playStyle.playStyleText = lorePlayStyle.innerHTML.trim();
+
+    //Set Complexity
+    const complexityHeader = loreBoardHTML.querySelectorAll("complexity")[0];
+    spiritBoardBack.complexity.complexityValue = complexityHeader.getAttribute("value");
+    spiritBoardBack.complexity.complexityDescriptor = complexityHeader.getAttribute("descriptor");
+
+    //Set Summary of Powers
+    const summaryPowersHeader = loreBoardHTML.querySelectorAll("summary-of-powers")[0];
+    var summaryPowersValues = summaryPowersHeader.getAttribute("values");
+    var summaryPowersSplit = summaryPowersValues.split(",");
+    spiritBoardBack.summary.offenseValue = summaryPowersSplit[0];
+    spiritBoardBack.summary.controlValue = summaryPowersSplit[1];
+    spiritBoardBack.summary.fearValue = summaryPowersSplit[2];
+    spiritBoardBack.summary.defenseValue = summaryPowersSplit[3];
+    spiritBoardBack.summary.utilityValue = summaryPowersSplit[4];
+    spiritBoardBack.summary.usesTokens = summaryPowersHeader.getAttribute("uses");
+
+    //Custom Icons
+    if (spiritBoardBack.demoBoardWasLoaded) {
+      const spiritStyle = htmlElement.querySelectorAll("style")[0];
+      customIcons.icons.splice(0, customIcons.icons.length); //Clear the Form first
+      if (spiritStyle) {
+        const regExp = new RegExp(/(?<=(["']))(?:(?=(\\?))\2.)*?(?=\1)/, "g");
+        let iconList = spiritStyle.textContent.match(regExp);
+        if (iconList) {
+          iconList.forEach((customIcon) => {
+            customIcons = Lib.addCustomIcon(customIcons, customIcon);
+            console.log(customIcon);
+          });
         }
       }
-      //Set Lore Description
-      const loreDescription = loreBoardHTML.querySelectorAll("lore-description")[0];
-
-      spiritBoardBack.lore.loreText = loreDescription.innerHTML.trim();
-
-      //Set Lore Setup
-      const loreSetup = loreBoardHTML.querySelectorAll("setup-description")[0];
-      spiritBoardBack.setup.setupText = loreSetup.innerHTML.trim();
-
-      //Set Lore Play Style
-      const lorePlayStyle = loreBoardHTML.querySelectorAll("play-style-description")[0];
-      spiritBoardBack.playStyle.playStyleText = lorePlayStyle.innerHTML.trim();
-
-      //Set Complexity
-      const complexityHeader = loreBoardHTML.querySelectorAll("complexity")[0];
-      spiritBoardBack.complexity.complexityValue = complexityHeader.getAttribute("value");
-      spiritBoardBack.complexity.complexityDescriptor = complexityHeader.getAttribute("descriptor");
-
-      //Set Summary of Powers
-      const summaryPowersHeader = loreBoardHTML.querySelectorAll("summary-of-powers")[0];
-      var summaryPowersValues = summaryPowersHeader.getAttribute("values");
-      var summaryPowersSplit = summaryPowersValues.split(",");
-      spiritBoardBack.summary.offenseValue = summaryPowersSplit[0];
-      spiritBoardBack.summary.controlValue = summaryPowersSplit[1];
-      spiritBoardBack.summary.fearValue = summaryPowersSplit[2];
-      spiritBoardBack.summary.defenseValue = summaryPowersSplit[3];
-      spiritBoardBack.summary.utilityValue = summaryPowersSplit[4];
-      spiritBoardBack.summary.usesTokens = summaryPowersHeader.getAttribute("uses");
-
-      //Custom Icons
-      if (spiritBoardBack.demoBoardWasLoaded) {
-        const spiritStyle = htmlElement.querySelectorAll("style")[0];
-        customIcons.icons.splice(0, customIcons.icons.length); //Clear the Form first
-        if (spiritStyle) {
-          const regExp = new RegExp(/(?<=(["']))(?:(?=(\\?))\2.)*?(?=\1)/, "g");
-          let iconList = spiritStyle.textContent.match(regExp);
-          if (iconList) {
-            iconList.forEach((customIcon) => {
-              customIcons = Lib.addCustomIcon(customIcons, customIcon);
-              console.log(customIcon);
-            });
-          }
-        }
-      } else {
-        console.log("SKIPPING ICON LOAD");
-      }
+    } else {
+      console.log("SKIPPING ICON LOAD");
     }
   }
 

--- a/src/routes/spirit-board/index.svelte
+++ b/src/routes/spirit-board/index.svelte
@@ -370,133 +370,131 @@
     console.log("Loading Spirit Board from HTML into form (f=readHTML)");
     console.log(htmlElement);
     //Reads the Template HTML file into the Form
-    if (frame) {
-      //Load Spirit Name and Image
-      const spiritName = htmlElement.querySelectorAll("spirit-name")[0];
-      if (spiritName) {
-        spiritBoard.nameAndArt.name = spiritName.textContent.trim();
-      }
-      const board = htmlElement.querySelectorAll("board")[0];
-      spiritBoard.nameAndArt.artPath = board.getAttribute("spirit-image");
-      spiritBoard.nameAndArt.artScale = board.getAttribute("spirit-image-scale");
-      spiritBoard.nameAndArt.bannerPath = board.getAttribute("spirit-border");
+    //Load Spirit Name and Image
+    const spiritName = htmlElement.querySelectorAll("spirit-name")[0];
+    if (spiritName) {
+      spiritBoard.nameAndArt.name = spiritName.textContent.trim();
+    }
+    const board = htmlElement.querySelectorAll("board")[0];
+    spiritBoard.nameAndArt.artPath = board.getAttribute("spirit-image");
+    spiritBoard.nameAndArt.artScale = board.getAttribute("spirit-image-scale");
+    spiritBoard.nameAndArt.bannerPath = board.getAttribute("spirit-border");
 
-      const artistName = htmlElement.querySelectorAll("artist-name")[0];
-      if (artistName) {
-        spiritBoard.nameAndArt.artistCredit = artistName.textContent.trim();
-      }
+    const artistName = htmlElement.querySelectorAll("artist-name")[0];
+    if (artistName) {
+      spiritBoard.nameAndArt.artistCredit = artistName.textContent.trim();
+    }
 
-      //Load Special Rules
-      const specialRulesNames = htmlElement.querySelectorAll("special-rules-subtitle");
-      const specialRulesEffects = htmlElement.querySelectorAll("special-rule");
-      spiritBoard.specialRules.rules.splice(0, spiritBoard.specialRules.rules.length); //Clear the Form first
-      specialRulesNames.forEach((specialRulesName, j) => {
-        spiritBoard = Lib.addSpecialRule(
+    //Load Special Rules
+    const specialRulesNames = htmlElement.querySelectorAll("special-rules-subtitle");
+    const specialRulesEffects = htmlElement.querySelectorAll("special-rule");
+    spiritBoard.specialRules.rules.splice(0, spiritBoard.specialRules.rules.length); //Clear the Form first
+    specialRulesNames.forEach((specialRulesName, j) => {
+      spiritBoard = Lib.addSpecialRule(
+        spiritBoard,
+        specialRulesName.textContent,
+        specialRulesEffects[j].innerHTML.trim()
+      );
+    });
+
+    //Load Growth
+    const growthContainer = htmlElement.querySelectorAll("growth");
+    var htmlGrowthSets = growthContainer[0].querySelectorAll("sub-growth");
+    var containerLayer;
+    if (htmlGrowthSets[0]) {
+      // if the HTML file isn't using subgroups (Growth Sets), then there's a whole layer that's missing... this gynamstics accounts for it.
+      spiritBoard.growth.useGrowthSets = true;
+      containerLayer = htmlGrowthSets;
+    } else {
+      containerLayer = growthContainer;
+    }
+
+    // Identify text inside the parathesis of the growth option (if any) ie. for Growth (Pick Two), this code will find Pick Two
+    var regExpOuterParentheses = /\(\s*(.+)\s*\)/;
+    let innerDirections = regExpOuterParentheses.exec(growthContainer[0].title);
+    spiritBoard.growth.directions = innerDirections !== null ? innerDirections[1] : "";
+
+    spiritBoard.growth.growthSets.splice(0, spiritBoard.growth.growthSets.length); //Clear the Form first
+    containerLayer.forEach((topGrowthLayer, i) => {
+      let groups = topGrowthLayer.querySelectorAll("growth-group");
+      spiritBoard = Lib.addGrowthSet(spiritBoard, containerLayer[i].getAttribute("title"));
+      groups.forEach((group, j) => {
+        spiritBoard = Lib.addGrowthGroup(
           spiritBoard,
-          specialRulesName.textContent,
-          specialRulesEffects[j].innerHTML.trim()
+          i,
+          group.getAttribute("cost"),
+          group.getAttribute("tint"),
+          group.getAttribute("special-title")
         );
-      });
-
-      //Load Growth
-      const growthContainer = htmlElement.querySelectorAll("growth");
-      var htmlGrowthSets = growthContainer[0].querySelectorAll("sub-growth");
-      var containerLayer;
-      if (htmlGrowthSets[0]) {
-        // if the HTML file isn't using subgroups (Growth Sets), then there's a whole layer that's missing... this gynamstics accounts for it.
-        spiritBoard.growth.useGrowthSets = true;
-        containerLayer = htmlGrowthSets;
-      } else {
-        containerLayer = growthContainer;
-      }
-
-      // Identify text inside the parathesis of the growth option (if any) ie. for Growth (Pick Two), this code will find Pick Two
-      var regExpOuterParentheses = /\(\s*(.+)\s*\)/;
-      let innerDirections = regExpOuterParentheses.exec(growthContainer[0].title);
-      spiritBoard.growth.directions = innerDirections !== null ? innerDirections[1] : "";
-
-      spiritBoard.growth.growthSets.splice(0, spiritBoard.growth.growthSets.length); //Clear the Form first
-      containerLayer.forEach((topGrowthLayer, i) => {
-        let groups = topGrowthLayer.querySelectorAll("growth-group");
-        spiritBoard = Lib.addGrowthSet(spiritBoard, containerLayer[i].getAttribute("title"));
-        groups.forEach((group, j) => {
-          spiritBoard = Lib.addGrowthGroup(
-            spiritBoard,
-            i,
-            group.getAttribute("cost"),
-            group.getAttribute("tint"),
-            group.getAttribute("special-title")
-          );
-          let values = group.getAttribute("values").split(";");
-          values.forEach((growthValue) => {
-            spiritBoard = Lib.addGrowthAction(spiritBoard, i, j, growthValue);
-          });
+        let values = group.getAttribute("values").split(";");
+        values.forEach((growthValue) => {
+          spiritBoard = Lib.addGrowthAction(spiritBoard, i, j, growthValue);
         });
       });
+    });
 
-      //Load Presence Tracks
+    //Load Presence Tracks
 
-      var presenceTracks = htmlElement.querySelectorAll("presence-tracks")[0];
-      var presenceNote = presenceTracks.getAttribute("note");
-      if (presenceNote) {
-        spiritBoard.presenceTrack.note = presenceNote;
-      } else {
-        spiritBoard.presenceTrack.note = "";
-      }
-      var energyTrack = htmlElement.querySelectorAll("energy-track")[0];
-      spiritBoard.nameAndArt.energyBannerPath = energyTrack.getAttribute("banner");
-      spiritBoard.nameAndArt.energyBannerScale = energyTrack.getAttribute("banner-v-scale");
-      var energyValues = energyTrack.getAttribute("values").split(",");
-      spiritBoard.presenceTrack.energyNodes.splice(0, spiritBoard.presenceTrack.energyNodes.length); //Clear the Form first
-      energyValues.forEach((value) => {
-        spiritBoard = Lib.addEnergyTrackNode(spiritBoard, value);
-      });
-      var playsTrack = htmlElement.querySelectorAll("card-play-track")[0];
-      spiritBoard.nameAndArt.playsBannerPath = playsTrack.getAttribute("banner");
-      spiritBoard.nameAndArt.playsBannerScale = playsTrack.getAttribute("banner-v-scale");
-      var playsValues = playsTrack.getAttribute("values").split(",");
-      spiritBoard.presenceTrack.playsNodes.splice(0, spiritBoard.presenceTrack.playsNodes.length); //Clear the Form first
-      playsValues.forEach((value) => {
-        spiritBoard = Lib.addPlaysTrackNode(spiritBoard, value);
-      });
+    var presenceTracks = htmlElement.querySelectorAll("presence-tracks")[0];
+    var presenceNote = presenceTracks.getAttribute("note");
+    if (presenceNote) {
+      spiritBoard.presenceTrack.note = presenceNote;
+    } else {
+      spiritBoard.presenceTrack.note = "";
+    }
+    var energyTrack = htmlElement.querySelectorAll("energy-track")[0];
+    spiritBoard.nameAndArt.energyBannerPath = energyTrack.getAttribute("banner");
+    spiritBoard.nameAndArt.energyBannerScale = energyTrack.getAttribute("banner-v-scale");
+    var energyValues = energyTrack.getAttribute("values").split(",");
+    spiritBoard.presenceTrack.energyNodes.splice(0, spiritBoard.presenceTrack.energyNodes.length); //Clear the Form first
+    energyValues.forEach((value) => {
+      spiritBoard = Lib.addEnergyTrackNode(spiritBoard, value);
+    });
+    var playsTrack = htmlElement.querySelectorAll("card-play-track")[0];
+    spiritBoard.nameAndArt.playsBannerPath = playsTrack.getAttribute("banner");
+    spiritBoard.nameAndArt.playsBannerScale = playsTrack.getAttribute("banner-v-scale");
+    var playsValues = playsTrack.getAttribute("values").split(",");
+    spiritBoard.presenceTrack.playsNodes.splice(0, spiritBoard.presenceTrack.playsNodes.length); //Clear the Form first
+    playsValues.forEach((value) => {
+      spiritBoard = Lib.addPlaysTrackNode(spiritBoard, value);
+    });
 
-      //Load Innate Powers
-      var innatePowers = htmlElement.querySelectorAll("quick-innate-power");
-      spiritBoard.innatePowers.powers.splice(0, spiritBoard.innatePowers.powers.length); //Clear the Form first
-      innatePowers.forEach((innatePower, k) => {
-        spiritBoard = Lib.addInnatePower(
+    //Load Innate Powers
+    var innatePowers = htmlElement.querySelectorAll("quick-innate-power");
+    spiritBoard.innatePowers.powers.splice(0, spiritBoard.innatePowers.powers.length); //Clear the Form first
+    innatePowers.forEach((innatePower, k) => {
+      spiritBoard = Lib.addInnatePower(
+        spiritBoard,
+        innatePower.getAttribute("name"),
+        innatePower.getAttribute("speed"),
+        innatePower.getAttribute("range"),
+        innatePower.getAttribute("target"),
+        innatePower.getAttribute("target-title"),
+        innatePower.getAttribute("note")
+      );
+      var htmlLevels = innatePower.querySelectorAll("level");
+      htmlLevels.forEach((htmlLevel) => {
+        spiritBoard = Lib.addLevel(
           spiritBoard,
-          innatePower.getAttribute("name"),
-          innatePower.getAttribute("speed"),
-          innatePower.getAttribute("range"),
-          innatePower.getAttribute("target"),
-          innatePower.getAttribute("target-title"),
-          innatePower.getAttribute("note")
+          k,
+          htmlLevel.getAttribute("threshold"),
+          htmlLevel.textContent.trim(),
+          htmlLevel.hasAttribute("long")
         );
-        var htmlLevels = innatePower.querySelectorAll("level");
-        htmlLevels.forEach((htmlLevel) => {
-          spiritBoard = Lib.addLevel(
-            spiritBoard,
-            k,
-            htmlLevel.getAttribute("threshold"),
-            htmlLevel.textContent.trim(),
-            htmlLevel.hasAttribute("long")
-          );
-        });
       });
+    });
 
-      //Load Custom Icons
-      const spiritStyle = htmlElement.querySelectorAll("style")[0];
-      customIcons.icons.splice(0, customIcons.icons.length); //Clear the Form first
-      if (spiritStyle) {
-        const regExp = new RegExp(/(?<=(["']))(?:(?=(\\?))\2.)*?(?=\1)/, "g");
-        let iconList = spiritStyle.textContent.match(regExp);
-        if (iconList) {
-          iconList.forEach((customIcon) => {
-            customIcons = Lib.addCustomIcon(customIcons, customIcon);
-            console.log(customIcon);
-          });
-        }
+    //Load Custom Icons
+    const spiritStyle = htmlElement.querySelectorAll("style")[0];
+    customIcons.icons.splice(0, customIcons.icons.length); //Clear the Form first
+    if (spiritStyle) {
+      const regExp = new RegExp(/(?<=(["']))(?:(?=(\\?))\2.)*?(?=\1)/, "g");
+      let iconList = spiritStyle.textContent.match(regExp);
+      if (iconList) {
+        iconList.forEach((customIcon) => {
+          customIcons = Lib.addCustomIcon(customIcons, customIcon);
+          console.log(customIcon);
+        });
       }
     }
   }


### PR DESCRIPTION
My guess is that this is a remnant of before `readHTML` was passed a HTML element to read from.

I've had a number of branches where I've been playing with cleaning up the HTML loading, where I've wanted to clean this up. Since it is worth doing anyway, it would be nice to just land this.