### PR TITLE
When loading HTML, resolve URLs relative to the document.

### DIFF
--- a/src/routes/adversary/index.svelte
+++ b/src/routes/adversary/index.svelte
@@ -15,8 +15,9 @@
   let previewFrame;
 
   async function loadHTMLFromURL(url) {
+    url = new URL(url, document.baseURI);
     let loadedDocument = await Lib.loadHTML(url);
-    readHTML(loadedDocument);
+    readHTML(loadedDocument, url);
     reloadPreview();
   }
 
@@ -74,14 +75,17 @@
     return fragment;
   }
 
-  function readHTML(htmlElement) {
+  function readHTML(htmlElement, baseURI) {
     console.log("Loading adversary into form (f=readHTML)");
     //Reads the Template HTML file into the Form
     //Load Adversary Name, Base Difficulty and Flag Image
     const adversaryHeader = htmlElement.querySelectorAll("quick-adversary")[0];
     adversary.nameLossEscalation.name = adversaryHeader.getAttribute("name");
     adversary.nameLossEscalation.baseDif = adversaryHeader.getAttribute("base-difficulty");
-    adversary.nameLossEscalation.flagImg = adversaryHeader.getAttribute("flag-image");
+    adversary.nameLossEscalation.flagImg = Lib.maybeResolveURL(
+      adversaryHeader.getAttribute("flag-image"),
+      baseURI
+    );
 
     //Load Loss Condition
     const lossConditionHeader = htmlElement.querySelectorAll("loss-condition")[0];
@@ -194,11 +198,7 @@
   }
 </script>
 
-<PreviewFrame
-  id="adversary-preview"
-  baseURI="/template/MyCustomContent/MyAdversary/"
-  bind:this={previewFrame}
-  on:hot-reload={reloadPreview}>
+<PreviewFrame id="adversary-preview" bind:this={previewFrame} on:hot-reload={reloadPreview}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/adversary.css" rel="stylesheet" />

--- a/src/routes/aspect/index.svelte
+++ b/src/routes/aspect/index.svelte
@@ -15,8 +15,9 @@
   let previewFrame;
 
   async function loadHTMLFromURL(url) {
+    url = new URL(url, document.baseURI);
     let loadedDocument = await Lib.loadHTML(url);
-    readHTML(loadedDocument);
+    readHTML(loadedDocument, url);
     reloadPreview();
   }
 
@@ -128,7 +129,7 @@
     return fragment;
   }
 
-  function readHTML(htmlElement) {
+  function readHTML(htmlElement, baseURI) {
     console.log("Loading aspect into form (f=readHTML)");
     //Reads the Template HTML file into the Form
     const aspectHTML = htmlElement.querySelectorAll("aspect")[0];
@@ -161,7 +162,10 @@
     console.log("^^^^");
     if (aspectBackHTML) {
       aspect.nameReplacements.spiritName = aspectBackHTML.getAttribute("spirit-name");
-      aspect.nameReplacements.spiritImage = aspectBackHTML.getAttribute("src");
+      aspect.nameReplacements.spiritImage = Lib.maybeResolveURL(
+        aspectBackHTML.getAttribute("src"),
+        baseURI
+      );
       aspect.nameReplacements.hasBack = true;
     } else {
       aspect.nameReplacements.hasBack = false;
@@ -297,11 +301,7 @@
   }
 </script>
 
-<PreviewFrame
-  id="aspect-preview"
-  baseURI="/template/MyCustomContent/MyAspect/"
-  bind:this={previewFrame}
-  on:hot-reload={reloadPreview}>
+<PreviewFrame id="aspect-preview" bind:this={previewFrame} on:hot-reload={reloadPreview}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/aspect.css" rel="stylesheet" />

--- a/src/routes/lib.js
+++ b/src/routes/lib.js
@@ -312,3 +312,22 @@ export async function loadHTML(url) {
   let parser = new DOMParser();
   return parser.parseFromString(await response.text(), "text/html");
 }
+
+/**
+ * If url is provided, resolve it relative to baseURI.
+ * Otherwise, return null.
+ *
+ * This is meant to be used when reading a possibly relative URL
+ * that may be missing from a document.
+ *
+ * @param {?(string|URL)} url
+ * @param {(string|URL)} baseURI
+ * @returns
+ */
+export const maybeResolveURL = (url, baseURI) => {
+  if (url) {
+    return new URL(url, baseURI);
+  } else {
+    return null;
+  }
+};

--- a/src/routes/power-cards/index.svelte
+++ b/src/routes/power-cards/index.svelte
@@ -16,8 +16,9 @@
   let previewFrame;
 
   async function loadHTMLFromURL(url) {
+    url = new URL(url, document.baseURI);
     let loadedDocument = await Lib.loadHTML(url);
-    readHTML(loadedDocument);
+    readHTML(loadedDocument, url);
     reloadPreview();
   }
 
@@ -90,7 +91,7 @@
     return fragment;
   }
 
-  function readHTML(htmlElement) {
+  function readHTML(htmlElement, baseURI) {
     console.log("Loading power cards into form (f=readHTML)");
     //Reads the Template HTML file into the Form
     const powerCardsHTML = htmlElement.querySelectorAll("quick-card");
@@ -101,7 +102,7 @@
 
     //Iterate through the cards
     powerCardsHTML.forEach((powerCardHTML) => {
-      addPowerCard(powerCards, powerCardHTML);
+      addPowerCard(powerCards, powerCardHTML, baseURI);
     });
 
     //Custom Icons
@@ -123,7 +124,7 @@
     }
   }
 
-  function addPowerCard(powerCards, powerCardHTML) {
+  function addPowerCard(powerCards, powerCardHTML, baseURI) {
     let rulesHTML = powerCardHTML.querySelectorAll("rules")[0];
     let rulesPush = "";
     if (rulesHTML) {
@@ -169,7 +170,7 @@
       name: powerCardHTML.getAttribute("name"),
       speed: powerCardHTML.getAttribute("speed"),
       cost: powerCardHTML.getAttribute("cost"),
-      cardImage: powerCardHTML.getAttribute("image"),
+      cardImage: Lib.maybeResolveURL(powerCardHTML.getAttribute("image"), baseURI),
       powerElements: elementsForm,
       range: powerCardHTML.getAttribute("range"),
       target: powerCardHTML.getAttribute("target"),
@@ -252,11 +253,7 @@
   }
 </script>
 
-<PreviewFrame
-  id="power-cards-preview"
-  baseURI="/template/MyCustomContent/MySpirit/"
-  bind:this={previewFrame}
-  on:hot-reload={reloadPreview}>
+<PreviewFrame id="power-cards-preview" bind:this={previewFrame} on:hot-reload={reloadPreview}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/card.css" rel="stylesheet" />

--- a/src/routes/spirit-board-back/index.svelte
+++ b/src/routes/spirit-board-back/index.svelte
@@ -17,8 +17,9 @@
   let previewFrame;
 
   async function loadHTMLFromURL(url) {
+    url = new URL(url, document.baseURI);
     let loadedDocument = await Lib.loadHTML(url);
-    readHTML(loadedDocument);
+    readHTML(loadedDocument, url);
     reloadPreview();
   }
 
@@ -131,7 +132,7 @@
     return fragment;
   }
 
-  function readHTML(htmlElement) {
+  function readHTML(htmlElement, baseURI) {
     console.log("Loading spirit lore board into form (f=readHTML)");
     //Reads the Template HTML file into the Form
     const loreBoardHTML = htmlElement.querySelectorAll("board")[0];
@@ -144,7 +145,7 @@
     //Set Spirit Image
     const loreImage = loreBoardHTML.querySelectorAll("img")[0];
     if (loreImage) {
-      spiritBoardBack.nameImage.img = loreImage.getAttribute("src");
+      spiritBoardBack.nameImage.img = Lib.maybeResolveURL(loreImage.getAttribute("src"), baseURI);
       let imgScale = loreImage.getAttribute("scale");
       console.log(imgScale);
       if (imgScale) {
@@ -189,6 +190,7 @@
         let iconList = spiritStyle.textContent.match(regExp);
         if (iconList) {
           iconList.forEach((customIcon) => {
+            customIcon = Lib.maybeResolveURL(customIcon, baseURI);
             customIcons = Lib.addCustomIcon(customIcons, customIcon);
             console.log(customIcon);
           });
@@ -266,11 +268,7 @@
   }
 </script>
 
-<PreviewFrame
-  id="lore-preview"
-  baseURI="/template/MyCustomContent/MySpirit/"
-  bind:this={previewFrame}
-  on:hot-reload={reloadPreview}>
+<PreviewFrame id="lore-preview" bind:this={previewFrame} on:hot-reload={reloadPreview}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/board_lore.css" rel="stylesheet" />

--- a/src/routes/spirit-board/index.svelte
+++ b/src/routes/spirit-board/index.svelte
@@ -150,8 +150,9 @@
   let exampleModal;
 
   async function loadHTMLFromURL(url) {
+    url = new URL(url, document.baseURI);
     let loadedDocument = await Lib.loadHTML(url);
-    readHTML(loadedDocument);
+    readHTML(loadedDocument, url);
     reloadPreview();
   }
 
@@ -342,7 +343,7 @@
     spiritBoard = spiritBoard;
   }
 
-  function readHTML(htmlElement) {
+  function readHTML(htmlElement, baseURI) {
     console.log("Loading Spirit Board from HTML into form (f=readHTML)");
     console.log(htmlElement);
     //Reads the Template HTML file into the Form
@@ -352,9 +353,15 @@
       spiritBoard.nameAndArt.name = spiritName.textContent.trim();
     }
     const board = htmlElement.querySelectorAll("board")[0];
-    spiritBoard.nameAndArt.artPath = board.getAttribute("spirit-image");
+    spiritBoard.nameAndArt.artPath = Lib.maybeResolveURL(
+      board.getAttribute("spirit-image"),
+      baseURI
+    );
     spiritBoard.nameAndArt.artScale = board.getAttribute("spirit-image-scale");
-    spiritBoard.nameAndArt.bannerPath = board.getAttribute("spirit-border");
+    spiritBoard.nameAndArt.bannerPath = Lib.maybeResolveURL(
+      board.getAttribute("spirit-border"),
+      baseURI
+    );
 
     const artistName = htmlElement.querySelectorAll("artist-name")[0];
     if (artistName) {
@@ -419,7 +426,10 @@
       spiritBoard.presenceTrack.note = "";
     }
     let energyTrack = htmlElement.querySelectorAll("energy-track")[0];
-    spiritBoard.nameAndArt.energyBannerPath = energyTrack.getAttribute("banner");
+    spiritBoard.nameAndArt.energyBannerPath = Lib.maybeResolveURL(
+      energyTrack.getAttribute("banner"),
+      baseURI
+    );
     spiritBoard.nameAndArt.energyBannerScale = energyTrack.getAttribute("banner-v-scale");
     let energyValues = energyTrack.getAttribute("values").split(",");
     spiritBoard.presenceTrack.energyNodes.splice(0, spiritBoard.presenceTrack.energyNodes.length); //Clear the Form first
@@ -427,7 +437,10 @@
       spiritBoard = Lib.addEnergyTrackNode(spiritBoard, value);
     });
     let playsTrack = htmlElement.querySelectorAll("card-play-track")[0];
-    spiritBoard.nameAndArt.playsBannerPath = playsTrack.getAttribute("banner");
+    spiritBoard.nameAndArt.playsBannerPath = Lib.maybeResolveURL(
+      playsTrack.getAttribute("banner"),
+      baseURI
+    );
     spiritBoard.nameAndArt.playsBannerScale = playsTrack.getAttribute("banner-v-scale");
     let playsValues = playsTrack.getAttribute("values").split(",");
     spiritBoard.presenceTrack.playsNodes.splice(0, spiritBoard.presenceTrack.playsNodes.length); //Clear the Form first
@@ -468,6 +481,7 @@
       let iconList = spiritStyle.textContent.match(regExp);
       if (iconList) {
         iconList.forEach((customIcon) => {
+          customIcon = Lib.maybeResolveURL(customIcon, baseURI);
           customIcons = Lib.addCustomIcon(customIcons, customIcon);
           console.log(customIcon);
         });
@@ -750,11 +764,7 @@
   }
 </script>
 
-<PreviewFrame
-  id="spirit-preview"
-  baseURI="/template/MyCustomContent/MySpirit/"
-  bind:this={previewFrame}
-  on:hot-reload={reloadPreview}>
+<PreviewFrame id="spirit-preview" bind:this={previewFrame} on:hot-reload={reloadPreview}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/board_front.css" rel="stylesheet" />


### PR DESCRIPTION
This is a followup to #180 that resolves URLs when loading HTML (this mainly effects the image paths for examples). This
removes the need to pass a `baseURI` to `<PreviewFrame>` (which was used to construct an appropriate `<base>` tag for in the frame).

This also causes the images to show in the editor portion, when loading examples, so the spirit image preview displayed for the spirit board front and back was adjusted to have a maximum height. The need for this was not apparent before, as the examples did not display an image here.