### PR TITLE
Add a helper to enable hot-reloading of the preview-frame.

### DIFF
--- a/src/lib/hmr-helper.js
+++ b/src/lib/hmr-helper.js
@@ -1,0 +1,41 @@
+/**
+ * A module that exposes the undocumented hooks for hot-reloading from svelte-hmr.
+ *
+ * @see https://github.com/sveltejs/svelte-hmr/issues/57
+ */
+import { dev } from "$app/environment";
+
+import { onMount, createEventDispatcher } from "svelte";
+
+import { get_current_component } from "svelte/internal";
+
+/**
+ * If running in the dev server, calls the given function when the component is reloaded.
+ * This should be called during component initialization.
+ *
+ * @param {() => void} callback
+ */
+export const onHotReload = (callback) => {
+  if (dev) {
+    const component = get_current_component();
+    onMount(() => {
+      component.$$.on_hmr?.push(() => () => {
+        callback();
+      });
+    });
+  }
+};
+
+/**
+ * If running in the dev server, configures the current component to dispatch
+ * a "hot-reload" event when the component is updated. This should be called
+ * during component initialization.
+ */
+export const installHotReloadEvent = () => {
+  if (dev) {
+    const dispatch = createEventDispatcher();
+    onHotReload(() => {
+      dispatch("hot-reload");
+    });
+  }
+};

--- a/src/lib/preview-frame/index.svelte
+++ b/src/lib/preview-frame/index.svelte
@@ -4,6 +4,7 @@
 
   import { tick, onMount } from "svelte";
   import { browser } from "$app/environment";
+  import { installHotReloadEvent } from "$lib/hmr-helper.js";
 
   // Using a query string of `?worker&url` gives a URL from which we can
   // pass to `<script type="module">` tag, which we can inject into the
@@ -76,8 +77,9 @@
       return loaded;
     }
   }
-
   onMount(updateSrc);
+
+  installHotReloadEvent();
 </script>
 
 <div {id} class="preview-wrap" class:large bind:this={wrapper}>

--- a/src/routes/adversary/index.svelte
+++ b/src/routes/adversary/index.svelte
@@ -12,7 +12,6 @@
   export let instructionsSource;
 
   let previewFrame;
-  let previewDoc;
 
   async function loadHTMLFromURL(url) {
     let loadedDocument = await Lib.loadHTML(url);
@@ -207,8 +206,7 @@
 <PreviewFrame
   id="adversary-preview"
   baseURI="/template/MyCustomContent/MyAdversary/"
-  bind:this={previewFrame}
-  bind:document={previewDoc}>
+  bind:this={previewFrame}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/adversary.css" rel="stylesheet" />

--- a/src/routes/adversary/index.svelte
+++ b/src/routes/adversary/index.svelte
@@ -206,7 +206,8 @@
 <PreviewFrame
   id="adversary-preview"
   baseURI="/template/MyCustomContent/MyAdversary/"
-  bind:this={previewFrame}>
+  bind:this={previewFrame}
+  on:hot-reload={reloadPreview}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/adversary.css" rel="stylesheet" />

--- a/src/routes/aspect/index.svelte
+++ b/src/routes/aspect/index.svelte
@@ -12,7 +12,6 @@
   export let instructionsSource;
 
   let previewFrame;
-  let previewDoc;
 
   async function loadHTMLFromURL(url) {
     let loadedDocument = await Lib.loadHTML(url);
@@ -310,8 +309,7 @@
 <PreviewFrame
   id="aspect-preview"
   baseURI="/template/MyCustomContent/MyAspect/"
-  bind:this={previewFrame}
-  bind:document={previewDoc}>
+  bind:this={previewFrame}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/aspect.css" rel="stylesheet" />

--- a/src/routes/aspect/index.svelte
+++ b/src/routes/aspect/index.svelte
@@ -309,7 +309,8 @@
 <PreviewFrame
   id="aspect-preview"
   baseURI="/template/MyCustomContent/MyAspect/"
-  bind:this={previewFrame}>
+  bind:this={previewFrame}
+  on:hot-reload={reloadPreview}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/aspect.css" rel="stylesheet" />

--- a/src/routes/power-cards/index.svelte
+++ b/src/routes/power-cards/index.svelte
@@ -264,7 +264,8 @@
 <PreviewFrame
   id="power-cards-preview"
   baseURI="/template/MyCustomContent/MySpirit/"
-  bind:this={previewFrame}>
+  bind:this={previewFrame}
+  on:hot-reload={reloadPreview}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/card.css" rel="stylesheet" />

--- a/src/routes/power-cards/index.svelte
+++ b/src/routes/power-cards/index.svelte
@@ -13,7 +13,6 @@
   export let instructionsSource;
 
   let previewFrame;
-  let previewDoc;
 
   async function loadHTMLFromURL(url) {
     let loadedDocument = await Lib.loadHTML(url);
@@ -265,8 +264,7 @@
 <PreviewFrame
   id="power-cards-preview"
   baseURI="/template/MyCustomContent/MySpirit/"
-  bind:this={previewFrame}
-  bind:document={previewDoc}>
+  bind:this={previewFrame}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/card.css" rel="stylesheet" />

--- a/src/routes/spirit-board-back/index.svelte
+++ b/src/routes/spirit-board-back/index.svelte
@@ -278,7 +278,8 @@
 <PreviewFrame
   id="lore-preview"
   baseURI="/template/MyCustomContent/MySpirit/"
-  bind:this={previewFrame}>
+  bind:this={previewFrame}
+  on:hot-reload={reloadPreview}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/board_lore.css" rel="stylesheet" />

--- a/src/routes/spirit-board-back/index.svelte
+++ b/src/routes/spirit-board-back/index.svelte
@@ -14,7 +14,6 @@
   export let instructionsSource;
 
   let previewFrame;
-  let previewDoc;
 
   async function loadHTMLFromURL(url) {
     let loadedDocument = await Lib.loadHTML(url);
@@ -279,8 +278,7 @@
 <PreviewFrame
   id="lore-preview"
   baseURI="/template/MyCustomContent/MySpirit/"
-  bind:this={previewFrame}
-  bind:document={previewDoc}>
+  bind:this={previewFrame}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/board_lore.css" rel="stylesheet" />

--- a/src/routes/spirit-board/index.svelte
+++ b/src/routes/spirit-board/index.svelte
@@ -146,7 +146,6 @@
   }
 
   let previewFrame;
-  let previewDoc;
   let exampleModal;
 
   async function loadHTMLFromURL(url) {
@@ -764,8 +763,7 @@
 <PreviewFrame
   id="spirit-preview"
   baseURI="/template/MyCustomContent/MySpirit/"
-  bind:this={previewFrame}
-  bind:document={previewDoc}>
+  bind:this={previewFrame}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/board_front.css" rel="stylesheet" />

--- a/src/routes/spirit-board/index.svelte
+++ b/src/routes/spirit-board/index.svelte
@@ -763,7 +763,8 @@
 <PreviewFrame
   id="spirit-preview"
   baseURI="/template/MyCustomContent/MySpirit/"
-  bind:this={previewFrame}>
+  bind:this={previewFrame}
+  on:hot-reload={reloadPreview}>
   <svelte:fragment slot="head">
     <link href="/template/_global/css/global.css" rel="stylesheet" />
     <link href="/template/_global/css/board_front.css" rel="stylesheet" />


### PR DESCRIPTION
This uses undocumented hook mentioned in https://github.com/sveltejs/svelte-hmr/issues/57 to automatically update the
preview frame, when the preview frame gets reloaded.