### PR TITLE
Refactor file inputs into components.

### DIFF
--- a/src/bulmaOverride.css
+++ b/src/bulmaOverride.css
@@ -39,9 +39,8 @@
   font-family: "JosefinSans-Regular";
 }
 
-.file.is-success .file-cta {
-  background-color: #0ba14a;
-  font-family: "JosefinSans-Regular";
+.button.is-file-load {
+  background-color: #ffe08a;
 }
 
 h1,

--- a/src/lib/image-input.svelte
+++ b/src/lib/image-input.svelte
@@ -1,0 +1,82 @@
+<script>
+  export let id;
+  export let title;
+  export let imageURL;
+  export let imageScale;
+  export let includeScale = false;
+
+  let files;
+
+  const handleInput = () => {
+    const file = files.item(0);
+    if (file) {
+      const fileReader = new FileReader();
+      fileReader.onload = (event) => {
+        imageURL = event.target.result;
+      };
+
+      // This reads the file and then triggers the onload function above once it finishes
+      fileReader.readAsDataURL(file);
+    }
+  };
+</script>
+
+<div class="field has-addons is-horizontal is-justify-content-left" class:mb-0={includeScale}>
+  <div class="field-label is-small">
+    <label class="label" for="{id}-input">{title}</label>
+  </div>
+  <div class="control">
+    <!-- Can use CSS to change how this looks. Maybe we could use a toggle to switch between file input and URL input -->
+    <input
+      id="{id}-file-input"
+      accept="image/png, image/jpeg"
+      bind:files
+      on:change={handleInput}
+      type="file"
+      class="input" />
+    <!-- Showing that the image is available -->
+    {#if imageURL}
+      <img src={imageURL} alt={title} />
+    {/if}
+    <div class="field has-addons is-horizontal is-justify-content-left mb-0">
+      <input
+        id="{id}-input"
+        class="input is-small"
+        type="text"
+        placeholder="File Name"
+        disabled
+        bind:value={imageURL} />
+      <button
+        class="button is-warning is-light is-small row-button"
+        on:click={() => (imageURL = "")}>
+        Remove
+      </button>
+    </div>
+    <!-- No need for a button because spiritBoard.nameAndArt.artPath is bound to this input already, and the image won't be loaded until the board gets generated again -->
+  </div>
+</div>
+<!-- Spirit Art Scale -->
+{#if includeScale}
+  <div class="field has-addons is-horizontal is-justify-content-left">
+    <div class="field-label is-small">
+      <label class="label" for="{id}-scale">Vertical Scale:</label>
+    </div>
+    <div class="control">
+      <input
+        id="{id}-scale"
+        class="input is-small"
+        type="text"
+        placeholder="%"
+        bind:value={imageScale} />
+    </div>
+  </div>
+{/if}
+
+<style>
+  img {
+    width: 100%;
+    max-height: 400px;
+    object-fit: contain;
+    object-position: center center;
+  }
+</style>

--- a/src/lib/load-button.svelte
+++ b/src/lib/load-button.svelte
@@ -1,0 +1,22 @@
+<script>
+  let classList;
+  export { classList as class };
+  export let accept;
+  export let loadObjectURL;
+
+  let fileInput;
+  let files;
+
+  const handleInput = () => {
+    const file = files.item(0);
+    if (file) {
+      let url = URL.createObjectURL(file);
+      Promise.resolve(loadObjectURL(url)).finally(() => {
+        URL.revokeObjectURL(url);
+      });
+    }
+  };
+</script>
+
+<input hidden type="file" {accept} bind:files bind:this={fileInput} on:change={handleInput} />
+<button class={classList} on:click={() => fileInput.click()}> <slot /> </button>

--- a/src/lib/load-button.svelte
+++ b/src/lib/load-button.svelte
@@ -3,6 +3,7 @@
   export { classList as class };
   export let accept;
   export let loadObjectURL;
+  export let loadDataURL;
 
   let fileInput;
   let files;
@@ -10,10 +11,21 @@
   const handleInput = () => {
     const file = files.item(0);
     if (file) {
-      let url = URL.createObjectURL(file);
-      Promise.resolve(loadObjectURL(url)).finally(() => {
-        URL.revokeObjectURL(url);
-      });
+      if (loadObjectURL) {
+        let url = URL.createObjectURL(file);
+        Promise.resolve(loadObjectURL(url)).finally(() => {
+          URL.revokeObjectURL(url);
+        });
+      }
+      if (loadDataURL) {
+        const fileReader = new FileReader();
+        fileReader.onload = (event) => {
+          loadDataURL(event.target.result);
+        };
+
+        // This reads the file and then triggers the onload function above once it finishes
+        fileReader.readAsDataURL(file);
+      }
     }
   };
 </script>

--- a/src/routes/adversary/index.svelte
+++ b/src/routes/adversary/index.svelte
@@ -3,6 +3,7 @@
 
   import * as Lib from "../lib";
   import PreviewFrame from "$lib/preview-frame/index.svelte";
+  import LoadButton from "$lib/load-button.svelte";
 
   import NameLossAndEscalation from "./name-loss-escalation.svelte";
   import AdversaryLevels from "./adversary-levels.svelte";
@@ -108,16 +109,6 @@
     Lib.downloadHTML(generateHTML(adversary), htmlFileName);
   }
 
-  function handleTextFileInput(event) {
-    const file = event.target.files.item(0);
-    if (file) {
-      let url = URL.createObjectURL(file);
-      loadHTMLFromURL(url).finally(() => {
-        URL.revokeObjectURL(url);
-      });
-    }
-  }
-
   function clearAllFields() {
     if (window.confirm("Are you sure? This permanently clears all fields in Adversary.")) {
       adversary = {
@@ -217,20 +208,10 @@
   </svelte:fragment>
 </PreviewFrame>
 <div class="field has-addons mb-2">
-  <div class="file is-success mr-1">
-    <label class="file-label">
-      <input
-        class="file-input"
-        id="userHTMLInput"
-        type="file"
-        name="userHTMLInput"
-        accept=".html"
-        on:change={handleTextFileInput} />
-      <span class="file-cta">
-        <span class="file-label"> Load </span>
-      </span>
-    </label>
-  </div>
+  <LoadButton accept=".html" class="button is-success mr-1" loadObjectURL={loadHTMLFromURL}>
+    Load
+  </LoadButton>
+
   <button class="button is-success  mr-1" on:click={exportAdversary}> Save </button>
   <button class="button is-success  mr-1" on:click={screenshotSetUp}>Download Image</button>
   <button class="button is-warning  mr-1" on:click={reloadPreview}>Update Preview</button>

--- a/src/routes/adversary/name-loss-escalation.svelte
+++ b/src/routes/adversary/name-loss-escalation.svelte
@@ -3,20 +3,7 @@
   import AutoComplete from "$lib/auto-complete/index.svelte";
   import { iconValuesSorted } from "$lib/auto-complete/autoCompleteValues";
   import Section from "$lib/section.svelte";
-
-  function handleImageFileInput(event) {
-    const file = event.target.files.item(0);
-    if (file) {
-      const fileReader = new FileReader();
-      fileReader.onload = (data) => {
-        const imageURL = data.target.result;
-        adversary.nameLossEscalation.flagImg = imageURL;
-      };
-
-      // This reads the file and then triggers the onload function above once it finishes
-      fileReader.readAsDataURL(file);
-    }
-  }
+  import ImageInput from "$lib/image-input.svelte";
 </script>
 
 <Section
@@ -54,26 +41,10 @@
       </div>
     </div>
     <!-- FLAG ART -->
-    <div class="field has-addons is-horizontal is-justify-content-left mb-0">
-      <div class="field-label is-small">
-        <label class="label" for="adversaryFlagArt">Flag Art</label>
-      </div>
-      <div class="control">
-        <input
-          accept="image/png, image/jpeg"
-          on:change={handleImageFileInput}
-          id="adversaryFlagArt"
-          name="adversaryFlagArt"
-          type="file"
-          class="input" />
-        {#if adversary.nameLossEscalation.flagImg}
-          <img
-            id="adversaryFlagArtImage"
-            src={adversary.nameLossEscalation.flagImg}
-            alt="flag art" />
-        {/if}
-      </div>
-    </div>
+    <ImageInput
+      id="adversaryFlag"
+      title="Flag Art"
+      bind:imageURL={adversary.nameLossEscalation.flagImg} />
   </div>
   <!-- Loss Condition -->
   <div class="field">

--- a/src/routes/aspect/index.svelte
+++ b/src/routes/aspect/index.svelte
@@ -3,6 +3,7 @@
 
   import * as Lib from "../lib";
   import PreviewFrame from "$lib/preview-frame/index.svelte";
+  import LoadButton from "$lib/load-button.svelte";
 
   import NameReplacements from "./name-replacements.svelte";
   import AspectEffects from "./aspect-effects.svelte";
@@ -222,16 +223,6 @@
     Lib.downloadHTML(generateHTML(aspect), htmlFileName);
   }
 
-  function handleTextFileInput(event) {
-    const file = event.target.files.item(0);
-    if (file) {
-      let url = URL.createObjectURL(file);
-      loadHTMLFromURL(url).finally(() => {
-        URL.revokeObjectURL(url);
-      });
-    }
-  }
-
   function clearAllFields() {
     if (window.confirm("Are you sure? This permanently clears all fields in Aspect.")) {
       aspect = {
@@ -321,20 +312,9 @@
 </PreviewFrame>
 
 <div class="field has-addons mb-2">
-  <div class="file is-success mr-1">
-    <label class="file-label">
-      <input
-        class="file-input is-success"
-        id="userHTMLInput"
-        type="file"
-        name="userHTMLInput"
-        accept=".html"
-        on:change={handleTextFileInput} />
-      <span class="file-cta">
-        <span class="file-label"> Load </span>
-      </span>
-    </label>
-  </div>
+  <LoadButton accept=".html" class="button is-success mr-1" loadObjectURL={loadHTMLFromURL}>
+    Load
+  </LoadButton>
   <button class="button is-success  mr-1" on:click={exportAspect}> Save </button>
   <button class="button is-success  mr-1" on:click={screenshotSetUp}>Download Image</button>
   <button class="button is-warning  mr-1" on:click={reloadPreview}>Update Preview</button>

--- a/src/routes/aspect/name-replacements.svelte
+++ b/src/routes/aspect/name-replacements.svelte
@@ -1,21 +1,8 @@
 <script>
   import Section from "$lib/section.svelte";
+  import ImageInput from "$lib/image-input.svelte";
 
   export let aspect;
-
-  function handleImageFileInput(event) {
-    const file = event.target.files.item(0);
-    if (file) {
-      const fileReader = new FileReader();
-      fileReader.onload = (data) => {
-        const imageURL = data.target.result;
-        aspect.nameReplacements.spiritImage = imageURL;
-      };
-
-      // This reads the file and then triggers the onload function above once it finishes
-      fileReader.readAsDataURL(file);
-    }
-  }
 
   function setComplexity(val, aspectHolder) {
     aspectHolder.complexity = val;
@@ -128,20 +115,7 @@
             bind:value={aspect.nameReplacements.spiritName} />
         </div>
       </div>
-      <div class="is-flex is-flex-direction-column is-flex-wrap-nowrap pb-0">
-        <div class="field has-addons mr-2 ml-1">
-          <label class="label is-unselectable mr-1" for="">Art: </label>
-          <div class="control">
-            <input
-              accept="image/png, image/jpeg"
-              on:change={handleImageFileInput}
-              id={`backArt`}
-              name="cardArt"
-              type="file"
-              class="input is-small" />
-          </div>
-        </div>
-      </div>
+      <ImageInput id="backArt" title="Art" bind:imageURL={aspect.nameReplacements.spiritImage} />
     {:else}
       <button class="button is-warning is-light is-small row-button" on:click={setBack}
         >Add Card Back</button>

--- a/src/routes/custom-icons.svelte
+++ b/src/routes/custom-icons.svelte
@@ -1,5 +1,6 @@
 <script>
   import Section from "$lib/section.svelte";
+  import LoadButton from "$lib/load-button.svelte";
   export let customIcons;
 
   function addCustomIcon() {
@@ -16,20 +17,6 @@
       icon.id = i;
     });
     customIcons = customIcons;
-  }
-
-  function handleImageFileInput(event, i) {
-    const file = event.target.files.item(0);
-    if (file) {
-      const fileReader = new FileReader();
-      fileReader.onload = (data) => {
-        const imageURL = data.target.result;
-        customIcons.icons[i].name = imageURL;
-      };
-
-      // This reads the file and then triggers the onload function above once it finishes
-      fileReader.readAsDataURL(file);
-    }
   }
 </script>
 
@@ -54,22 +41,13 @@
           src={icon.name}
           alt={`custom${i + 1}`} />
       {/if}
-      <div class="file is-warning is-small">
-        <label class="file-label">
-          <input
-            class="file-input"
-            id={`customIconInput${i}`}
-            type="file"
-            name={`customIconInput${i}`}
-            accept="image/png, image/jpeg"
-            on:change={(e) => {
-              handleImageFileInput(e, i);
-            }} />
-          <span class="file-cta">
-            <span class="file-label"> Load </span>
-          </span>
-        </label>
-      </div>
+      <LoadButton
+        accept="image/png, image/jpeg"
+        class="button is-file-load is-small"
+        loadDataURL={(url) => {
+          icon.name = url;
+        }}>Load</LoadButton>
+
       <button class="button is-warning is-light is-small row-button" on:click={removeCustomIcon(i)}
         >Remove</button>
     </div>

--- a/src/routes/power-cards/index.svelte
+++ b/src/routes/power-cards/index.svelte
@@ -3,6 +3,7 @@
 
   import * as Lib from "../lib";
   import PreviewFrame from "$lib/preview-frame/index.svelte";
+  import LoadButton from "$lib/load-button.svelte";
 
   import PowerCard from "./power-card.svelte";
   import CustomIcons from "../custom-icons.svelte";
@@ -190,16 +191,6 @@
     Lib.downloadHTML(generateHTML(powerCards), htmlFileName);
   }
 
-  function handleTextFileInput(event) {
-    const file = event.target.files.item(0);
-    if (file) {
-      let url = URL.createObjectURL(file);
-      loadHTMLFromURL(url).finally(() => {
-        URL.revokeObjectURL(url);
-      });
-    }
-  }
-
   function clearAllFields() {
     if (window.confirm("Are you sure? This permanently clears all fields in Power Cards.")) {
       powerCards = {
@@ -275,20 +266,9 @@
   </svelte:fragment>
 </PreviewFrame>
 <div class="field has-addons mt-2 mb-2">
-  <div class="file is-success mr-1">
-    <label class="file-label">
-      <input
-        class="file-input"
-        id="userHTMLInput"
-        type="file"
-        name="userHTMLInput"
-        accept=".html"
-        on:change={handleTextFileInput} />
-      <span class="file-cta">
-        <span class="file-label"> Load </span>
-      </span>
-    </label>
-  </div>
+  <LoadButton accept=".html" class="button is-success mr-1" loadObjectURL={loadHTMLFromURL}>
+    Load
+  </LoadButton>
   <button class="button is-success  mr-1" on:click={exportPowerCards}> Save </button>
   <button class="button is-success  mr-1" on:click={screenshotSetUp}>Download Image</button>
   <button class="button is-warning  mr-1" on:click={reloadPreview}>Update Preview</button>

--- a/src/routes/power-cards/power-card.svelte
+++ b/src/routes/power-cards/power-card.svelte
@@ -3,20 +3,7 @@
   import AutoComplete from "$lib/auto-complete/index.svelte";
   import { iconValuesSorted } from "$lib/auto-complete/autoCompleteValues";
   import Section from "$lib/section.svelte";
-
-  function handleImageFileInput(event, card) {
-    const file = event.target.files.item(0);
-    if (file) {
-      const fileReader = new FileReader();
-      fileReader.onload = (data) => {
-        const imageURL = data.target.result;
-        card.cardImage = imageURL;
-      };
-
-      // This reads the file and then triggers the onload function above once it finishes
-      fileReader.readAsDataURL(file);
-    }
-  }
+  import ImageInput from "$lib/image-input.svelte";
 
   function setSpeedTextbox(powerSpeed, card) {
     card.speed = powerSpeed;
@@ -271,7 +258,7 @@
     <div class="is-flex is-flex-direction-column is-flex-wrap-nowrap pb-4">
       <div class="field has-addons mr-2 ml-1">
         <label class="label is-unselectable mr-1" for="">Artist: </label>
-        <div class="control">
+        <div class="control mr-2">
           <input
             id={`cardArtist${i}`}
             class="input is-small"
@@ -279,18 +266,7 @@
             placeholder="Artist"
             bind:value={card.cardArtist} />
         </div>
-        <div class="control">
-          <input
-            accept="image/png, image/jpeg"
-            on:change={(e) => handleImageFileInput(e, card)}
-            id={`cardArt${i}`}
-            name="cardArt"
-            type="file"
-            class="input is-small" />
-          {#if card.cardImage === ""}
-            <img id="cardArtImage" src={card.cardImage} alt="power card art" />
-          {/if}
-        </div>
+        <ImageInput id="cardArt{i}" title="Card Art" bind:imageURL={card.cardImage} />
       </div>
     </div>
     <hr />

--- a/src/routes/spirit-board-back/index.svelte
+++ b/src/routes/spirit-board-back/index.svelte
@@ -3,6 +3,7 @@
 
   import * as Lib from "../lib";
   import PreviewFrame from "$lib/preview-frame/index.svelte";
+  import LoadButton from "$lib/load-button.svelte";
 
   import NameArtLore from "./name-art-lore.svelte";
   import SetupPlaystyleComplexityPowers from "./setup-playstyle-complexity-powers.svelte";
@@ -204,16 +205,6 @@
     Lib.downloadHTML(generateHTML(spiritBoardBack), htmlFileName);
   }
 
-  function handleTextFileInput(event) {
-    const file = event.target.files.item(0);
-    if (file) {
-      let url = URL.createObjectURL(file);
-      loadHTMLFromURL(url).finally(() => {
-        URL.revokeObjectURL(url);
-      });
-    }
-  }
-
   function clearAllFields() {
     if (
       window.confirm("Are you sure? This permanently clears all fields in Spirit Board Lore Side.")
@@ -289,20 +280,9 @@
   </svelte:fragment>
 </PreviewFrame>
 <div class="field has-addons mb-2">
-  <div class="file is-success mr-1">
-    <label class="file-label">
-      <input
-        class="file-input"
-        id="userHTMLInput"
-        type="file"
-        name="userHTMLInput"
-        accept=".html"
-        on:change={handleTextFileInput} />
-      <span class="file-cta">
-        <span class="file-label"> Load </span>
-      </span>
-    </label>
-  </div>
+  <LoadButton accept=".html" class="button is-success mr-1" loadObjectURL={loadHTMLFromURL}>
+    Load
+  </LoadButton>
   <button class="button is-success  mr-1" on:click={exportSpiritBoardBack}> Save </button>
   <button class="button is-success  mr-1" on:click={screenshotSetUp}>Download Image</button>
   <button class="button is-warning  mr-1" on:click={reloadPreview}>Update Preview</button>

--- a/src/routes/spirit-board-back/name-art-lore.svelte
+++ b/src/routes/spirit-board-back/name-art-lore.svelte
@@ -1,26 +1,8 @@
 <script>
   import Section from "$lib/section.svelte";
+  import ImageInput from "$lib/image-input.svelte";
 
   export let spiritBoardBack;
-
-  function handleImageFileInput(event) {
-    const file = event.target.files.item(0);
-    if (file) {
-      const fileReader = new FileReader();
-      fileReader.onload = (data) => {
-        const imageURL = data.target.result;
-        spiritBoardBack.nameImage.img = imageURL;
-        spiritBoardBack.nameImage.scale = 100;
-      };
-
-      // This reads the file and then triggers the onload function above once it finishes
-      fileReader.readAsDataURL(file);
-    }
-  }
-
-  function removeArtSpirit() {
-    spiritBoardBack.nameImage.img = "";
-  }
 </script>
 
 <Section title="Name, Art and Lore" bind:isVisible={spiritBoardBack.nameArtLore.isVisible}>
@@ -48,40 +30,12 @@
       </div>
     </div>
     <!-- Spirit ART -->
-    <div class="field has-addons is-horizontal is-justify-content-left mb-0">
-      <div class="field-label is-small">
-        <label class="label" for="adversaryFlagArt">Spirit Art</label>
-      </div>
-      <div class="control">
-        <div class="field has-addons mb-0">
-          <input
-            accept="image/png, image/jpeg"
-            on:change={handleImageFileInput}
-            id="spiritLoreArt"
-            name="spiritLoreArt"
-            type="file"
-            class="input" />
-          <button class="button is-warning is-light row-button" on:click={removeArtSpirit}
-            >Remove</button>
-        </div>
-        {#if spiritBoardBack.nameImage.img}
-          <img id="spiritLoreArtImage" src={spiritBoardBack.nameImage.img} alt="spirit lore art" />
-        {/if}
-      </div>
-    </div>
-    <div class="field has-addons is-horizontal is-justify-content-left">
-      <div class="field-label is-small">
-        <label class="label" for="spiritArtInput">Scale (%):</label>
-      </div>
-      <div class="control">
-        <input
-          id="spiritArtScale"
-          class="input is-small"
-          type="text"
-          placeholder="%"
-          bind:value={spiritBoardBack.nameImage.scale} />
-      </div>
-    </div>
+    <ImageInput
+      id="spiritLoreArt"
+      title="Spirit Art"
+      includeScale
+      bind:imageURL={spiritBoardBack.nameImage.img}
+      bind:imageScale={spiritBoardBack.nameImage.scale} />
   </div>
   <!-- Lore -->
   <div class="field">

--- a/src/routes/spirit-board/index.svelte
+++ b/src/routes/spirit-board/index.svelte
@@ -5,6 +5,7 @@
   import * as Lib from "../lib";
   import PreviewFrame from "$lib/preview-frame/index.svelte";
   import Examples from "$lib/example-modal.svelte";
+  import LoadButton from "$lib/load-button.svelte";
 
   import NameAndArt from "./name-and-art.svelte";
   import SpecialRules from "./special-rules.svelte";
@@ -483,17 +484,6 @@
     document.getElementById("updateButton").classList.remove("is-flashy");
   }
 
-  function handleTextFileInput(event) {
-    hideAll();
-    const file = event.target.files.item(0);
-    if (file) {
-      let url = URL.createObjectURL(file);
-      loadHTMLFromURL(url).finally(() => {
-        URL.revokeObjectURL(url);
-      });
-    }
-  }
-
   function exportSpiritBoard() {
     const htmlFileName = spiritBoard.nameAndArt.name.replaceAll(" ", "_") + "_SpiritBoard.html";
     Lib.downloadHTML(generateHTML(spiritBoard), htmlFileName);
@@ -782,21 +772,10 @@
     on:click={exampleModal.open}>
     Examples
   </button>
-  <div class="file is-success mr-1">
-    <label class="file-label">
-      <input
-        class="file-input is-success"
-        id="userHTMLInput"
-        type="file"
-        name="userHTMLInput"
-        accept=".html"
-        on:change={handleTextFileInput} />
-      <span class="file-cta">
-        <span class="file-label"> Load </span>
-      </span>
-    </label>
-  </div>
-  <button class="button is-success  mr-1" on:click={exportSpiritBoard}> Save </button>
+  <LoadButton accept=".html" class="button is-success mr-1" loadObjectURL={loadHTMLFromURL}>
+    Load
+  </LoadButton>
+  <button class="button is-success  mr-1" on:click={exportSpiritBoard}>Save</button>
   <button class="button is-success  mr-1" on:click={screenshotSetUp}>Download Image</button>
   <button class="button is-success  mr-1" on:click={downloadTTSJSON}>Export TTS file</button>
   <button class="button is-warning  mr-1" id="updateButton" on:click={reloadPreview}

--- a/src/routes/spirit-board/name-and-art.svelte
+++ b/src/routes/spirit-board/name-and-art.svelte
@@ -1,45 +1,6 @@
 <script>
   import Section from "$lib/section.svelte";
-
-  function handleImageFileInput(event) {
-    const file = event.target.files.item(0);
-    if (file) {
-      const fileReader = new FileReader();
-      fileReader.onload = (data) => {
-        const imageURL = data.target.result;
-
-        const targetId = event.target.id;
-        if (targetId.toLowerCase().includes("spiritart")) {
-          spiritBoard.nameAndArt.artPath = imageURL;
-        } else if (targetId.toLowerCase().includes("spiritbanner")) {
-          spiritBoard.nameAndArt.bannerPath = imageURL;
-        } else if (targetId.toLowerCase().includes("energybanner")) {
-          spiritBoard.nameAndArt.energyBannerPath = imageURL;
-        } else if (targetId.toLowerCase().includes("playsbanner")) {
-          spiritBoard.nameAndArt.playsBannerPath = imageURL;
-        }
-      };
-
-      // This reads the file and then triggers the onload function above once it finishes
-      fileReader.readAsDataURL(file);
-    }
-  }
-
-  function removeArtSpirit() {
-    spiritBoard.nameAndArt.artPath = "";
-  }
-
-  function removeArtBanner() {
-    spiritBoard.nameAndArt.bannerPath = "";
-  }
-
-  function removeArtEnergy() {
-    spiritBoard.nameAndArt.energyBannerPath = "";
-  }
-
-  function removeArtPlays() {
-    spiritBoard.nameAndArt.playsBannerPath = "";
-  }
+  import ImageInput from "$lib/image-input.svelte";
 
   // exports allow for properties to be passed into this component. So the value of spiritBoard can be set by whatever component is the parent of this one. See https://svelte.dev/tutorial/declaring-props
   export let spiritBoard;
@@ -57,185 +18,31 @@
     </div>
   </div>
   <!-- Spirit Art -->
-  <div class="field has-addons is-horizontal is-justify-content-left mb-0">
-    <div class="field-label is-small">
-      <label class="label" for="spiritArtInput">Spirit Art</label>
-    </div>
-    <div class="control">
-      <!-- Can use CSS to change how this looks. Maybe we could use a toggle to switch between file input and URL input -->
-      <input
-        accept="image/png, image/jpeg"
-        on:change={handleImageFileInput}
-        id="spiritArtFileInput"
-        name="spiritArtFileInput"
-        type="file"
-        class="input" />
-      <!-- Showing that the image is available -->
-      {#if spiritBoard.nameAndArt.artPath}
-        <img id="spiritArtInputImage" src={spiritBoard.nameAndArt.artPath} alt="spirit art" />
-      {/if}
-      <div class="field has-addons is-horizontal is-justify-content-left mb-0">
-        <input
-          id="spiritArtInput"
-          class="input is-small"
-          type="text"
-          placeholder="File Name"
-          disabled
-          bind:value={spiritBoard.nameAndArt.artPath} />
-        <button class="button is-warning is-light is-small row-button" on:click={removeArtSpirit}
-          >Remove</button>
-      </div>
-      <!-- No need for a button because spiritBoard.nameAndArt.artPath is bound to this input already, and the image won't be loaded until the board gets generated again -->
-    </div>
-  </div>
-  <!-- Spirit Art Scale -->
-  <div class="field has-addons is-horizontal is-justify-content-left">
-    <div class="field-label is-small">
-      <label class="label" for="spiritArtInput">Scale:</label>
-    </div>
-    <div class="control">
-      <input
-        id="spiritArtScale"
-        class="input is-small"
-        type="text"
-        placeholder="%"
-        bind:value={spiritBoard.nameAndArt.artScale} />
-    </div>
-  </div>
+  <ImageInput
+    id="spiritArt"
+    title="Spirit Art"
+    includeScale
+    bind:imageURL={spiritBoard.nameAndArt.artPath}
+    bind:imageScale={spiritBoard.nameAndArt.artScale} />
   <!-- Banner Art -->
-  <div class="field has-addons is-horizontal is-justify-content-left">
-    <div class="field-label is-small">
-      <label class="label" for="spiritBannerInput">Banner Art</label>
-    </div>
-    <div class="control">
-      <!-- Can use CSS to change how this looks. Maybe we could use a toggle to switch between file input and URL input -->
-      <input
-        accept="image/png, image/jpeg"
-        on:change={handleImageFileInput}
-        id="spiritBannerFileInput"
-        name="spiritBannerFileInput"
-        type="file"
-        class="input" />
-      <!-- Showing that the image is available -->
-      {#if spiritBoard.nameAndArt.bannerPath}
-        <img
-          id="spiritBannerInputImage"
-          src={spiritBoard.nameAndArt.bannerPath}
-          alt="spirit banner" />
-      {/if}
-      <div class="field has-addons is-horizontal is-justify-content-left mb-0">
-        <input
-          id="spiritBannerInput"
-          class="input is-small"
-          type="text"
-          placeholder="File Name"
-          disabled
-          bind:value={spiritBoard.nameAndArt.bannerPath} />
-        <button class="button is-warning is-light is-small row-button" on:click={removeArtBanner}
-          >Remove</button>
-      </div>
-      <!-- No need for a button because spiritBoard.nameAndArt.artPath is bound to this input already, and the image won't be loaded until the board gets generated again -->
-    </div>
-  </div>
+  <ImageInput
+    id="spiritBanner"
+    title="Banner Art"
+    bind:imageURL={spiritBoard.nameAndArt.bannerPath} />
   <!-- Energy Track Banner -->
-  <div class="field has-addons is-horizontal is-justify-content-left mb-0">
-    <div class="field-label is-small">
-      <label class="label" for="energyBannerInput">Energy Track Banner</label>
-    </div>
-    <div class="control">
-      <!-- Can use CSS to change how this looks. Maybe we could use a toggle to switch between file input and URL input -->
-      <input
-        accept="image/png, image/jpeg"
-        on:change={handleImageFileInput}
-        id="energyBannerFileInput"
-        name="energyBannerFileInput"
-        type="file"
-        class="input" />
-      <!-- Showing that the image is available -->
-      {#if spiritBoard.nameAndArt.energyBannerPath}
-        <img
-          id="spiritArtInputImage"
-          src={spiritBoard.nameAndArt.energyBannerPath}
-          alt="energy banner art" />
-      {/if}
-      <div class="field has-addons is-horizontal is-justify-content-left mb-0">
-        <input
-          id="energyBannerInput"
-          class="input is-small"
-          type="text"
-          placeholder="File Name"
-          disabled
-          bind:value={spiritBoard.nameAndArt.energyBannerPath} />
-        <button class="button is-warning is-light is-small row-button" on:click={removeArtEnergy}
-          >Remove</button>
-      </div>
-      <!-- No need for a button because spiritBoard.nameAndArt.artPath is bound to this input already, and the image won't be loaded until the board gets generated again -->
-    </div>
-  </div>
-  <!-- Energy Track Banner Scale -->
-  <div class="field has-addons is-horizontal is-justify-content-left">
-    <div class="field-label is-small">
-      <label class="label" for="energyBannerScale">Vertical Scale:</label>
-    </div>
-    <div class="control">
-      <input
-        id="energyBannerScale"
-        class="input is-small"
-        type="text"
-        placeholder="%"
-        bind:value={spiritBoard.nameAndArt.energyBannerScale} />
-    </div>
-  </div>
-
+  <ImageInput
+    id="energyBanner"
+    title="Energy Track Banner"
+    includeScale
+    bind:imageURL={spiritBoard.nameAndArt.energyBannerPath}
+    bind:imageScale={spiritBoard.nameAndArt.energyBannerScale} />
   <!-- Plays Track Banner -->
-  <div class="field has-addons is-horizontal is-justify-content-left mb-0">
-    <div class="field-label is-small">
-      <label class="label" for="playsBannerInput">Plays Track Banner</label>
-    </div>
-    <div class="control">
-      <!-- Can use CSS to change how this looks. Maybe we could use a toggle to switch between file input and URL input -->
-      <input
-        accept="image/png, image/jpeg"
-        on:change={handleImageFileInput}
-        id="playsBannerFileInput"
-        name="playsBannerFileInput"
-        type="file"
-        class="input" />
-      <!-- Showing that the image is available -->
-      {#if spiritBoard.nameAndArt.playsBannerPath}
-        <img
-          id="spiritArtInputImage"
-          src={spiritBoard.nameAndArt.playsBannerPath}
-          alt="plays banner art" />
-      {/if}
-      <div class="field has-addons is-horizontal is-justify-content-left mb-0">
-        <input
-          id="playsBannerInput"
-          class="input is-small"
-          type="text"
-          placeholder="File Name"
-          disabled
-          bind:value={spiritBoard.nameAndArt.playsBannerPath} />
-        <button class="button is-warning is-light is-small row-button" on:click={removeArtPlays}
-          >Remove</button>
-      </div>
-      <!-- No need for a button because spiritBoard.nameAndArt.artPath is bound to this input already, and the image won't be loaded until the board gets generated again -->
-    </div>
-  </div>
-  <!-- Plays Track Banner Scale -->
-  <div class="field has-addons is-horizontal is-justify-content-left">
-    <div class="field-label is-small">
-      <label class="label" for="playsBannerScale">Vertical Scale:</label>
-    </div>
-    <div class="control">
-      <input
-        id="playsBannerScale"
-        class="input is-small"
-        type="text"
-        placeholder="%"
-        bind:value={spiritBoard.nameAndArt.playsBannerScale} />
-    </div>
-  </div>
+  <ImageInput
+    id="playsBanner"
+    title="Plays Track Banner"
+    includeScale
+    bind:imageURL={spiritBoard.nameAndArt.playsBannerPath}
+    bind:imageScale={spiritBoard.nameAndArt.playsBannerScale} />
   <!-- Artist Credits -->
   <div class="field">
     <label class="label" for="spiritArtistCreditInput">Artist Credit(s)</label>


### PR DESCRIPTION
This is based on #187.

This adds two new components, and uses them everywhere:
- `<LoadButton>` wraps a button and a hidden `<input type=file>`. When the button is clicked, it passes that to the hidden input, which displays a file dialog to load a file. Once the user has selected a file, the component executes a callback, passing either a object URL or a data URL. I think this is simpler than having a transparent input nested in a label, where clicking the label implicitly triggers the dialog. In particular, I think it is easier to style this, than the previous setup. This is used by all the Load HTML buttons, as well as the custom icon load buttons.
- `<ImageInput>` wraps a `<input type=file>`, an image preview, a URL display and optionally a image scale input. This makes all of the inputs consistent. This is used for all the non-custom-icon art inputs. 