### PR TITLE
Add `jsconfig.json` to enable language server to understand `$lib`.

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": false
+  }
+  // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias and https://kit.svelte.dev/docs/configuration#files
+  //
+  // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
+  // from the referenced tsconfig.json - TypeScript does not merge them in
+}


### PR DESCRIPTION
This imports the file from https://github.com/sveltejs/kit-template-default, but disables checking javascript files. This makes VS Code able to to follow imports from `$lib`, and auto-generate imports using `$lib`.