### PR TITLE
Remove the use of eslint-disable-next-line for fallthrough.

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,4 +23,5 @@ module.exports = {
     "no-var": "error",
     "eqeqeq": "error",
   },
+  reportUnusedDisableDirectives: true,
 };

--- a/src/routes/lib.js
+++ b/src/routes/lib.js
@@ -252,14 +252,14 @@ export const nextNode = (event) => {
           break;
         }
         currentID = focusID;
-      // eslint-disable-next-line no-fallthrough
+      // Intentionally fallthrough.
       case "setgrouptint":
         focusID = currentID.replace("tint", "title");
         if (document.getElementById(focusID) !== null) {
           break;
         }
         currentID = focusID;
-      // eslint-disable-next-line no-fallthrough
+      // Intentionally fallthrough.
       case "setgrouptitle":
         focusID = "growthSet" + numMatches[0] + "Group" + numMatches[1] + "Action0";
         break;


### PR DESCRIPTION
The eslint rule `no-fallthrough` looks for the word `fallthrough`on the previous line to disable the warning when deliberately falling through. Thus using
```
// eslint-disable-next-line no-fallthrough
```
causes the lint to not trigger (beacause it has the word fallthrough), as well as disables that lint. This causes the `eslint-disable-next-line` to be considered unused.

This also enables `reportUnusedDisableDirectives`, which would have reported this error. I discovered this when I had enabled that option for unrelated reasons.