### PR TITLE
Improve the instructions popup.

### DIFF
--- a/src/lib/instructions/index.svelte
+++ b/src/lib/instructions/index.svelte
@@ -2,11 +2,17 @@
   import { removeOutline, expandOutline, exitOutline, close as closeIcon } from "ionicons/icons";
 
   let isMinimized = false;
-  export let isShowingInstructions;
-  export let instructionsSource;
 
   let popup;
   let dragBar;
+
+  const source = new URL("https://neubee.github.io/spirit-island-builder/instructions");
+  export const open = (fragement) => {
+    if (fragement) {
+      source.hash = fragement;
+    }
+    popup.show();
+  };
 
   function dragPointerDown(e) {
     if (!e.isPrimary || e.button !== 0) {
@@ -58,24 +64,18 @@
   }
 
   function closeWindow() {
-    isShowingInstructions = !isShowingInstructions;
+    popup.close();
   }
 </script>
 
-<popup
+<dialog
   bind:this={popup}
   data-minimized={isMinimized}
-  style="height: 20rem; width: 50ch; --top: 32; --left: 32"
-  style:display={isShowingInstructions ? null : "none"}>
+  style="height: 20rem; width: 50ch; --top: 32; --left: 32">
   <header class="is-flex is-justify-content-space-between">
     <div class="drag-bar" bind:this={dragBar} on:pointerdown={dragPointerDown}>Instructions</div>
     <div class="is-flex px-2">
-      <a
-        href={instructionsSource}
-        on:click={closeWindow}
-        class="mr-1"
-        target="_blank"
-        rel="noreferrer">
+      <a href={source} on:click={closeWindow} class="mr-1" target="_blank" rel="noreferrer">
         <span title="Open in new tab"><ion-icon icon={exitOutline} /></span>
       </a>
       <button on:click={minimizeWindow} class="mr-1">
@@ -90,39 +90,40 @@
       </button>
     </div>
   </header>
-  <iframe
-    src={instructionsSource}
-    title="instructions"
-    id="instructionsFrame"
-    hidden={isMinimized} />
-</popup>
+  <iframe src={source} title="instructions" id="instructionsFrame" hidden={isMinimized} />
+</dialog>
 
 <style>
-  popup {
+  dialog {
     position: fixed;
     z-index: 999;
     border: 2px solid #b2b2b2;
     background-color: #e1e1e1;
     overflow-y: hidden;
-    display: flex;
     flex-direction: column;
     box-sizing: content-box;
     user-select: none;
     /* We use clamp to keep the position of the popup inside the viewport. */
     top: clamp(0px, var(--top) * 1px, 100vh - 2rem);
     left: clamp(-30ch, var(--left) * 1px, 100vw - 12ch);
+    /* reset */
+    padding: 0;
+    margin: 0;
+  }
+  dialog[open] {
+    display: flex;
   }
 
-  popup[data-minimized="false"] {
+  dialog[data-minimized="false"] {
     resize: both;
     min-width: 40ch;
     min-height: 8rem;
   }
 
-  popup[data-minimized="true"] {
+  dialog[data-minimized="true"] {
     resize: none;
-    min-height: 2rem;
-    max-height: 2rem;
+    min-height: 0;
+    max-height: 0;
   }
 
   header {

--- a/src/lib/instructions/index.svelte
+++ b/src/lib/instructions/index.svelte
@@ -45,7 +45,7 @@
 <popup
   bind:this={popup}
   data-minimized={isMinimized}
-  style="height: 20rem; width: 50ch"
+  style="height: 20rem; width: 50ch; top: 1rem; left: 1rem"
   style:display={isShowingInstructions ? null : "none"}>
   <header class="is-flex is-justify-content-space-between" on:mousedown={dragMouseDown}>
     <div>Instructions</div>
@@ -71,7 +71,7 @@
 
 <style>
   popup {
-    position: absolute;
+    position: fixed;
     z-index: 999;
     border: 2px solid #b2b2b2;
     background-color: #e1e1e1;

--- a/src/lib/instructions/index.svelte
+++ b/src/lib/instructions/index.svelte
@@ -4,7 +4,6 @@
   let isMinimized = false;
   export let isShowingInstructions;
   export let instructionsSource;
-  let iframeHeight = "250px";
 
   let popup;
 
@@ -35,92 +34,66 @@
   }
 
   function minimizeWindow() {
-    const instructionsWindow = document.getElementById("movableDialog");
-    const rootStyle = document.querySelector(":root");
-    rootStyle.style.setProperty("--windowWidth", `${instructionsWindow.clientWidth}px`);
     isMinimized = !isMinimized;
   }
 
   function closeWindow() {
     isShowingInstructions = !isShowingInstructions;
   }
-
-  function onMouseMove(event) {
-    if (event.target.id === "movableDialog") {
-      iframeHeight = `${event.target.clientHeight - 50}px`;
-    }
-  }
 </script>
 
-<div
-  id="movableDialog"
+<popup
   bind:this={popup}
-  class={`movableDialog ${isMinimized ? "closed" : "open"}`}>
-  <div
-    id="movableDialog-header"
-    class="movableDialog-header is-flex is-justify-content-space-between"
-    on:mousedown={dragMouseDown}>
+  data-minimized={isMinimized}
+  style="height: 20rem; width: 50ch"
+  style:display={isShowingInstructions ? null : "none"}>
+  <header class="is-flex is-justify-content-space-between" on:mousedown={dragMouseDown}>
     <div>Instructions</div>
     <div class="is-flex">
-      <button on:click={minimizeWindow} class="headerButtons mr-1">
+      <button on:click={minimizeWindow} class="mr-1">
         {#if isMinimized === false}
           <span title="Minimize"><ion-icon icon={removeOutline} /></span>
         {:else}
           <span title="Expand"><ion-icon icon={expandOutline} /></span>
         {/if}
       </button>
-      <button on:click={closeWindow} class="headerButtons">
+      <button on:click={closeWindow}>
         <span title="Close"><ion-icon icon={closeIcon} /></span>
       </button>
     </div>
-  </div>
-  <div class={`${isMinimized ? "iframeClosed" : "iframeOpen"}`}>
-    <iframe
-      src={instructionsSource}
-      width="100%"
-      height={iframeHeight}
-      title="instructions"
-      id="instructionsFrame" />
-  </div>
-</div>
+  </header>
+  <iframe
+    src={instructionsSource}
+    title="instructions"
+    id="instructionsFrame"
+    hidden={isMinimized} />
+</popup>
 
 <style>
-  .movableDialog {
+  popup {
     position: absolute;
     z-index: 999;
     border: 2px solid #b2b2b2;
-  }
-
-  .open {
-    min-width: 500px;
-    height: 300px;
-    width: 500px;
     background-color: #e1e1e1;
     overflow-y: hidden;
+    display: flex;
+    flex-direction: column;
+    box-sizing: content-box;
+  }
+
+  popup[data-minimized="false"] {
     resize: both;
+    min-width: 40ch;
+    min-height: 8rem;
   }
 
-  :root {
-    --windowWidth: 500px;
-  }
-  .closed {
-    background-color: #e1e1e100;
-    overflow-y: hidden;
+  popup[data-minimized="true"] {
     resize: none;
-    width: var(--windowWidth);
-    height: 45px;
-    border: none;
+    min-height: 2rem;
+    max-height: 2rem;
   }
 
-  .iframeOpen {
-    display: inherit;
-  }
-
-  .iframeClosed {
-    display: none;
-  }
-
-  .movableDialog-header {
+  header {
     padding-inline: 0.75rem;
     padding-block: 0.25rem;
     cursor: move;
@@ -128,7 +101,7 @@
     color: #fff;
   }
 
-  .headerButtons {
+  header button {
     display: block;
     cursor: pointer;
     /* reset */
@@ -139,7 +112,12 @@
     color: unset;
     background: unset;
   }
-  .headerButtons ion-icon {
+  header button ion-icon {
     display: block;
+  }
+
+  iframe {
+    width: 100%;
+    flex-grow: 1;
   }
 </style>

--- a/src/lib/instructions/index.svelte
+++ b/src/lib/instructions/index.svelte
@@ -90,6 +90,7 @@
     display: flex;
     flex-direction: column;
     box-sizing: content-box;
+    user-select: none;
     /* We use clamp to keep the position of the popup inside the viewport. */
     top: clamp(0px, var(--top) * 1px, 100vh - 2rem);
     left: clamp(-30ch, var(--left) * 1px, 100vw - 12ch);

--- a/src/lib/instructions/index.svelte
+++ b/src/lib/instructions/index.svelte
@@ -11,6 +11,9 @@
     // get the mouse cursor position at startup:
     let lastMouseX = e.clientX;
     let lastMouseY = e.clientY;
+    // Set the desired position to the actual position.
+    popup.style.setProperty("--top", popup.offsetTop);
+    popup.style.setProperty("--left", popup.offsetLeft);
     document.addEventListener("mouseup", closeDragElement);
     // call a function whenever the cursor moves:
     document.addEventListener("mousemove", elementDrag);
@@ -22,8 +25,8 @@
       lastMouseX = e.clientX;
       lastMouseY = e.clientY;
       // set the element's new position:
-      popup.style.top = `${popup.offsetTop - changeY}px`;
-      popup.style.left = `${popup.offsetLeft - changeX}px`;
+      popup.style.setProperty("--top", popup.style.getPropertyValue("--top") - changeY);
+      popup.style.setProperty("--left", popup.style.getPropertyValue("--left") - changeX);
     }
 
     function closeDragElement() {
@@ -45,7 +48,7 @@
 <popup
   bind:this={popup}
   data-minimized={isMinimized}
-  style="height: 20rem; width: 50ch; top: 1rem; left: 1rem"
+  style="height: 20rem; width: 50ch; --top: 32; --left: 32"
   style:display={isShowingInstructions ? null : "none"}>
   <header class="is-flex is-justify-content-space-between" on:mousedown={dragMouseDown}>
     <div>Instructions</div>
@@ -87,6 +90,9 @@
     display: flex;
     flex-direction: column;
     box-sizing: content-box;
+    /* We use clamp to keep the position of the popup inside the viewport. */
+    top: clamp(0px, var(--top) * 1px, 100vh - 2rem);
+    left: clamp(-30ch, var(--left) * 1px, 100vw - 12ch);
   }
 
   popup[data-minimized="false"] {

--- a/src/lib/instructions/index.svelte
+++ b/src/lib/instructions/index.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { removeOutline, expandOutline, close as closeIcon } from "ionicons/icons";
+  import { removeOutline, expandOutline, exitOutline, close as closeIcon } from "ionicons/icons";
 
   let isMinimized = false;
   export let isShowingInstructions;
@@ -50,6 +50,14 @@
   <header class="is-flex is-justify-content-space-between" on:mousedown={dragMouseDown}>
     <div>Instructions</div>
     <div class="is-flex">
+      <a
+        href={instructionsSource}
+        on:click={closeWindow}
+        class="mr-1"
+        target="_blank"
+        rel="noreferrer">
+        <span title="Open in new tab"><ion-icon icon={exitOutline} /></span>
+      </a>
       <button on:click={minimizeWindow} class="mr-1">
         {#if isMinimized === false}
           <span title="Minimize"><ion-icon icon={removeOutline} /></span>
@@ -112,8 +120,14 @@
     color: unset;
     background: unset;
   }
-  header button ion-icon {
+  header :is(button, a) ion-icon {
     display: block;
+  }
+
+  header a {
+    display: flex;
+    place-items: center;
+    color: unset;
   }
 
   iframe {

--- a/src/lib/instructions/index.svelte
+++ b/src/lib/instructions/index.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { onMount } from "svelte";
   import { removeOutline, expandOutline, close as closeIcon } from "ionicons/icons";
 
   let isMinimized = false;
@@ -7,52 +6,31 @@
   export let instructionsSource;
   let iframeHeight = "250px";
 
-  function initDragElement() {
-    let pos1 = 0,
-      pos2 = 0,
-      pos3 = 0,
-      pos4 = 0;
-    let popup = document.getElementById("movableDialog");
-    let elmnt = null;
-    let headerItem = document.getElementById("movableDialog-header");
+  let popup;
 
-    if (headerItem) {
-      headerItem.parentPopup = popup;
-      headerItem.onmousedown = dragMouseDown;
-    }
-
-    function dragMouseDown(e) {
-      elmnt = this.parentPopup;
-
-      e = e || window.event;
-      // get the mouse cursor position at startup:
-      pos3 = e.clientX;
-      pos4 = e.clientY;
-      document.onmouseup = closeDragElement;
-      // call a function whenever the cursor moves:
-      document.onmousemove = elementDrag;
-    }
+  function dragMouseDown(e) {
+    // get the mouse cursor position at startup:
+    let lastMouseX = e.clientX;
+    let lastMouseY = e.clientY;
+    document.addEventListener("mouseup", closeDragElement);
+    // call a function whenever the cursor moves:
+    document.addEventListener("mousemove", elementDrag);
 
     function elementDrag(e) {
-      if (!elmnt) {
-        return;
-      }
-
-      e = e || window.event;
       // calculate the new cursor position:
-      pos1 = pos3 - e.clientX;
-      pos2 = pos4 - e.clientY;
-      pos3 = e.clientX;
-      pos4 = e.clientY;
+      let changeX = lastMouseX - e.clientX;
+      let changeY = lastMouseY - e.clientY;
+      lastMouseX = e.clientX;
+      lastMouseY = e.clientY;
       // set the element's new position:
-      elmnt.style.top = elmnt.offsetTop - pos2 + "px";
-      elmnt.style.left = elmnt.offsetLeft - pos1 + "px";
+      popup.style.top = `${popup.offsetTop - changeY}px`;
+      popup.style.left = `${popup.offsetLeft - changeX}px`;
     }
 
     function closeDragElement() {
       /* stop moving when mouse button is released:*/
-      document.onmouseup = null;
-      document.onmousemove = null;
+      document.removeEventListener("mouseup", closeDragElement);
+      document.removeEventListener("mousemove", elementDrag);
     }
   }
 
@@ -67,10 +45,6 @@
     isShowingInstructions = !isShowingInstructions;
   }
 
-  onMount(() => {
-    initDragElement();
-  });
-
   function onMouseMove(event) {
     if (event.target.id === "movableDialog") {
       iframeHeight = `${event.target.clientHeight - 50}px`;
@@ -80,11 +54,12 @@
 
 <div
   id="movableDialog"
-  class={`movableDialog ${isMinimized ? "closed" : "open"}`}
-  on:mousemove={onMouseMove}>
+  bind:this={popup}
+  class={`movableDialog ${isMinimized ? "closed" : "open"}`}>
   <div
     id="movableDialog-header"
-    class="movableDialog-header is-flex is-justify-content-space-between">
+    class="movableDialog-header is-flex is-justify-content-space-between"
+    on:mousedown={dragMouseDown}>
     <div>Instructions</div>
     <div class="is-flex">
       <button on:click={minimizeWindow} class="headerButtons mr-1">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -384,9 +384,7 @@
     {/if}
   </nav>
 </header>
-{#if isShowingInstructions === true}
-  <Instructions bind:isShowingInstructions bind:instructionsSource />
-{/if}
+<Instructions bind:isShowingInstructions bind:instructionsSource />
 <div class="container">
   {#if currentPage === "spiritBoardFront"}
     <SpiritBoard

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -342,8 +342,7 @@
     },
   };
 
-  let isShowingInstructions = false;
-  let instructionsSource = "https://neubee.github.io/spirit-island-builder/instructions";
+  let instructions;
 
   let pages = [
     ["spiritBoardFront", "Spirit Board Play Side"],
@@ -384,30 +383,18 @@
     {/if}
   </nav>
 </header>
-<Instructions bind:isShowingInstructions bind:instructionsSource />
+<Instructions bind:this={instructions} />
 <div class="container">
   {#if currentPage === "spiritBoardFront"}
-    <SpiritBoard
-      bind:spiritBoard
-      bind:isShowingInstructions
-      bind:instructionsSource
-      bind:customIcons />
+    <SpiritBoard bind:spiritBoard bind:customIcons bind:instructions />
   {:else if currentPage === "spiritBoardBack"}
-    <SpiritBoardBack
-      bind:spiritBoardBack
-      bind:isShowingInstructions
-      bind:instructionsSource
-      bind:customIcons />
+    <SpiritBoardBack bind:spiritBoardBack bind:customIcons bind:instructions />
   {:else if currentPage === "powerCards"}
-    <PowerCards
-      bind:powerCards
-      bind:isShowingInstructions
-      bind:instructionsSource
-      bind:customIcons />
+    <PowerCards bind:powerCards bind:customIcons bind:instructions />
   {:else if currentPage === "aspect"}
-    <Aspect bind:aspect bind:isShowingInstructions bind:instructionsSource />
+    <Aspect bind:aspect bind:instructions />
   {:else if currentPage === "adversary"}
-    <Adversary bind:adversary bind:isShowingInstructions bind:instructionsSource />
+    <Adversary bind:adversary bind:instructions />
   {/if}
 </div>
 

--- a/src/routes/adversary/index.svelte
+++ b/src/routes/adversary/index.svelte
@@ -10,8 +10,7 @@
   import AdversaryLevels from "./adversary-levels.svelte";
 
   export let adversary;
-  export let isShowingInstructions;
-  export let instructionsSource;
+  export let instructions;
 
   let previewFrame;
 
@@ -188,8 +187,7 @@
   }
 
   function showInstructions() {
-    isShowingInstructions = true;
-    instructionsSource = "https://neubee.github.io/spirit-island-builder/instructions#adversary";
+    instructions.open("adversary");
   }
 
   function screenshotSetUp() {

--- a/src/routes/aspect/index.svelte
+++ b/src/routes/aspect/index.svelte
@@ -10,8 +10,7 @@
   import { downloadHTML } from "$lib/download";
 
   export let aspect;
-  export let isShowingInstructions;
-  export let instructionsSource;
+  export let instructions;
 
   let previewFrame;
 
@@ -288,8 +287,7 @@
   }
 
   function showInstructions() {
-    isShowingInstructions = true;
-    instructionsSource = "https://neubee.github.io/spirit-island-builder/instructions#power-cards";
+    instructions.open("power-cards");
   }
 
   function screenshotSetUp() {

--- a/src/routes/power-cards/index.svelte
+++ b/src/routes/power-cards/index.svelte
@@ -15,8 +15,7 @@
 
   export let powerCards;
   export let customIcons;
-  export let isShowingInstructions;
-  export let instructionsSource;
+  export let instructions;
 
   let previewFrame;
 
@@ -243,8 +242,7 @@
   }
 
   function showInstructions() {
-    isShowingInstructions = true;
-    instructionsSource = "https://neubee.github.io/spirit-island-builder/instructions#power-cards";
+    instructions.open("power-cards");
   }
 
   function screenshotSetUp() {

--- a/src/routes/spirit-board-back/index.svelte
+++ b/src/routes/spirit-board-back/index.svelte
@@ -12,8 +12,7 @@
 
   export let spiritBoardBack;
   export let customIcons;
-  export let isShowingInstructions;
-  export let instructionsSource;
+  export let instructions;
 
   let previewFrame;
 
@@ -255,9 +254,7 @@
   }
 
   function showInstructions() {
-    isShowingInstructions = true;
-    instructionsSource =
-      "https://neubee.github.io/spirit-island-builder/instructions#spirit-board-lore-side";
+    instructions.open("spirit-board-lore-side");
   }
 
   function screenshotSetUp() {

--- a/src/routes/spirit-board/index.svelte
+++ b/src/routes/spirit-board/index.svelte
@@ -22,8 +22,7 @@
 
   export let spiritBoard;
   export let customIcons;
-  export let isShowingInstructions;
-  export let instructionsSource;
+  export let instructions;
 
   function clearAllFields() {
     if (
@@ -504,9 +503,7 @@
   }
 
   function showInstructions() {
-    isShowingInstructions = true;
-    instructionsSource =
-      "https://neubee.github.io/spirit-island-builder/instructions#spirit-board-play-side";
+    instructions.open("spirit-board-play-side");
   }
 
   async function loadExample(example) {


### PR DESCRIPTION
- Simplify the javascript associated with the instructions popup.
  - Use a svelte binding, rather than looking up elements by id.
  - Use `document.addListener` rather to capture mouse events mouse events.
- Simplify CSS for instructions popup.
- Preserve size and position of instructions popup when closed.
- Make instructions fixed relative to the window rather than the document.
- Add link to view the instructions in a new tab.
- Ensure that the instruction popup can't be dragged offscreen.
- Prevent selecting text in the popup header.
  - Since clicking on it will move the popup, also selecting text while you do so is confusing.
- Use pointer events, rather than mouse events for dragging.
  - This should work better on mobile.
  - Use pointer capture to ensure that dragging works well over the preview frame.
- Use a `<dialog>` for instructions popup.

I think this addresses all but the second point from #52.