### PR TITLE
fix "Cost" Icon being on next line in innate powers in firefox

### DIFF
--- a/static/template/_global/css/board_front/innate-power.css
+++ b/static/template/_global/css/board_front/innate-power.css
@@ -684,6 +684,7 @@ cost-threshold {
   text-transform: capitalize;
   position: relative;
   margin-right: -30px;
+  display: inline flow-root;
 }
 
 cost-energy {


### PR DESCRIPTION
On firefox, when looking at Spreading Rot the mushrooms with the numbers are not where they should be. This did fix it.